### PR TITLE
Fixed bug #697: Remote validation uses wrong error messages

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1184,7 +1184,7 @@ $.extend($.validator, {
 			if (!this.settings.messages[element.name] ) {
 				this.settings.messages[element.name] = {};
 			}
-			previous.originalMessage = this.settings.messages[element.name].remote;
+			previous.originalMessage = previous.originalMessage || this.settings.messages[element.name].remote;
 			this.settings.messages[element.name].remote = previous.message;
 
 			param = typeof param === "string" && { url: param } || param;


### PR DESCRIPTION
This change doesn't break any existing unit test, but there is no additional tests. It would be great if somebody could create these tests, because I don't know how to do it.