### PR TITLE
Ignore rules with null or undefined

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1001,8 +1001,8 @@ $.extend( $.validator, {
 	normalizeRules: function( rules, element ) {
 		// handle dependency check
 		$.each( rules, function( prop, val ) {
-			// ignore rule when param is explicitly false, eg. required:false
-			if ( val === false ) {
+			// ignore rule when param is explicitly false, null or undefined, eg. required:false
+			if ( val === false || val === null || val === undefined ) {
 				delete rules[ prop ];
 				return;
 			}

--- a/test/index.html
+++ b/test/index.html
@@ -362,6 +362,10 @@
 		<input id="radiocheckbox-1-2" autocomplete="off" type="checkbox" name="radiocheckbox-1" required="required">
 		<input id="radiocheckbox-1-3" autocomplete="off" type="checkbox" name="radiocheckbox-1" required="required">
 	</form>
+  <form id="nullundefinedtest">
+    <input type="text" name="firstnamerequirednull" id="firstnamerequirednull">
+    <input type="text" name="firstnamerequiredundefined" id="firstnamerequiredundefined">
+  </form>
 </div>
 </body>
 </html>

--- a/test/rules.js
+++ b/test/rules.js
@@ -20,6 +20,30 @@ test("rules(), ignore method:false", function() {
 	deepEqual( element.rules(), { minlength: 2 } );
 });
 
+test("rules(), ignore method:null", function() {
+    var element = $("#firstnamerequirednull");
+
+    $("#nullundefinedtest").validate({
+        rules: {
+            firstnamerequirednull: { required: null, minlength: 2 }
+        }
+    });
+
+    deepEqual( element.rules(), { minlength: 2 } );
+});
+
+test("rules(), ignore method:undefined", function() {
+    var element = $("#firstnamerequiredundefined");
+
+    $("#nullundefinedtest").validate({
+        rules: {
+            firstnamerequiredundefined: { required: undefined, minlength: 2 }
+        }
+    });
+
+    deepEqual( element.rules(), { minlength: 2 } );
+});
+
 test("rules() HTML5 required (no value)", function() {
 	var element = $("#testForm11text1");
 


### PR DESCRIPTION
Just like it ignores explicit `false`, it should ignores `null` and `undefined` since those don't respond to `.param` neither.

Error: http://jsfiddle.net/MYLuL/