### PR TITLE
Proposed fix for #1378 - Added parseFloat before value and param are com...

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1216,12 +1216,12 @@ $.extend( $.validator, {
 
 		// http://jqueryvalidation.org/min-method/
 		min: function( value, element, param ) {
-			return this.optional( element ) || value >= param;
+			return this.optional( element ) || parseFloat( value ) >= parseFloat( param );
 		},
 
 		// http://jqueryvalidation.org/max-method/
 		max: function( value, element, param ) {
-			return this.optional( element ) || value <= param;
+			return this.optional( element ) || parseFloat( value ) <= parseFloat( param );
 		},
 
 		// http://jqueryvalidation.org/range-method/


### PR DESCRIPTION
Fix #1378 - value and param variables should be typecast before
comparison. This is required if rules are specified through
data-attributes