### PR TITLE
Core: Skip validation when settings is empty

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -348,7 +348,7 @@ $.extend( $.validator, {
 			function delegate( event ) {
 				var validator = $.data( this[ 0 ].form, "validator" ),
 					eventType = "on" + event.type.replace( /^validate/, "" ),
-					settings = validator.settings;
+					settings = validator && validator.settings ? validator.settings : [];
 				if ( settings[ eventType ] && !this.is( settings.ignore ) ) {
 					settings[ eventType ].call( validator, this[ 0 ], event );
 				}
@@ -1011,7 +1011,7 @@ $.extend( $.validator, {
 		var rules = {},
 			validator = $.data( element.form, "validator" );
 
-		if ( validator.settings.rules ) {
+		if ( validator && validator.settings && validator.settings.rules ) {
 			rules = $.validator.normalizeRule( validator.settings.rules[ element.name ] ) || {};
 		}
 		return rules;


### PR DESCRIPTION
My case is using jquery-validation with [jquery-upload-file plugin](https://github.com/hayageek/jquery-upload-file), these's a dynamic created form inside the original form and it's not able to get the correct settings. The solution is to skip the validation if the settings not found.
reproduce the issue: http://jsbin.com/macixayoyo/3/