### PR TITLE
throw better errors for bad rule methods

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -632,6 +632,9 @@ $.extend( $.validator, {
 					if ( this.settings.debug && window.console ) {
 						console.log( "Exception occurred when checking element " + element.id + ", check the '" + rule.method + "' method.", e );
 					}
+					if (e instanceof TypeError){
+						e.message += ".  Exception occurred when checking element " + element.id + ", check the '" + rule.method + "' method.";
+					}
 					throw e;
 				}
 			}


### PR DESCRIPTION
99% of type errors in this situation are misspelled rules, so be
specific in the throw.

I see it come up a lot in questions on SO.  It might be smart to even add a link to a FAQ on jqueryvalidation.org directly into the error message.