### PR TITLE
Binding to same unified object as '$'

### DIFF
--- a/src/additional/statesUS.js
+++ b/src/additional/statesUS.js
@@ -35,7 +35,7 @@
  *
  */
 
-jQuery.validator.addMethod("stateUS", function(value, element, options) {
+$.validator.addMethod("stateUS", function(value, element, options) {
 	var isDefault = typeof options === "undefined",
 		caseSensitive = ( isDefault || typeof options.caseSensitive === "undefined" ) ? false : options.caseSensitive,
 		includeTerritories = ( isDefault || typeof options.includeTerritories === "undefined" ) ? false : options.includeTerritories,


### PR DESCRIPTION
All other validation methods are bound to $ but this one was bound to 'JQuery' , it is causing error when you have two versions of jQuery and want to bind all these methods to one of jQuery instance.