### PR TITLE
Core: Exclude some keyboard keys to prevent revalidate the field

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -259,7 +259,25 @@ $.extend( $.validator, {
 			}
 		},
 		onkeyup: function( element, event ) {
-			if ( event.which === 9 && this.elementValue( element ) === "" ) {
+			// Avoid revalidate the field when pressing one of the following keys
+			// Shift       => 16
+			// Alt         => 18
+			// Caps lock   => 20
+			// End         => 35
+			// Home        => 36
+			// Left arrow  => 37
+			// Up arrow    => 38
+			// Right arrow => 39
+			// Down arrow  => 40
+			// Insert      => 45
+			// Num lock    => 144
+			// AltGr key   => 225
+			var excludedKeys = [
+				16, 18, 20, 35, 36, 37,
+				38, 39, 40, 45, 144, 225
+			];
+
+			if ( event.which === 9 && this.elementValue( element ) === "" || excludedKeys.indexOf( event.which ) !== -1 ) {
 				return;
 			} else if ( element.name in this.submitted || element === this.lastElement ) {
 				this.element( element );

--- a/src/core.js
+++ b/src/core.js
@@ -261,6 +261,7 @@ $.extend( $.validator, {
 		onkeyup: function( element, event ) {
 			// Avoid revalidate the field when pressing one of the following keys
 			// Shift       => 16
+			// Ctrl        => 17
 			// Alt         => 18
 			// Caps lock   => 20
 			// End         => 35
@@ -273,11 +274,11 @@ $.extend( $.validator, {
 			// Num lock    => 144
 			// AltGr key   => 225
 			var excludedKeys = [
-				16, 18, 20, 35, 36, 37,
+				16, 17, 18, 20, 35, 36, 37,
 				38, 39, 40, 45, 144, 225
 			];
 
-			if ( event.which === 9 && this.elementValue( element ) === "" || excludedKeys.indexOf( event.which ) !== -1 ) {
+			if ( event.which === 9 && this.elementValue( element ) === "" || excludedKeys.indexOf( event.keyCode ) !== -1 ) {
 				return;
 			} else if ( element.name in this.submitted || element === this.lastElement ) {
 				this.element( element );

--- a/test/test.js
+++ b/test/test.js
@@ -1284,6 +1284,56 @@ test( "validate email on keyup and blur", function() {
 	errors( 0 );
 });
 
+test( "don't revalidate the field when pressing special characters", function() {
+	function errors( expected, message ) {
+		equal( expected, v.size(), message );
+	}
+
+	function triggerEvent( element, keycode ) {
+		var event = $.Event( "keyup", { keyCode: keycode } );
+		element.trigger( event );
+	}
+
+	var e = $( "#firstname" ),
+		v = $( "#testForm1" ).validate(),
+		excludedKeys = {
+			"Shift": 16,
+			"Ctrl": 17,
+			"Alt": 18,
+			"Caps lock": 20,
+			"End": 35,
+			"Home": 36,
+			"Left arrow": 37,
+			"Up arrow": 38,
+			"Right arrow": 39,
+			"Down arrow": 40,
+			"Insert": 45,
+			"Num lock": 144,
+			"Alt GR": 225
+		};
+
+	// To make sure there is only one error, that one of #firtname field
+	$( "#firstname" ).val( "" );
+	$( "#lastname" ).val( "something" );
+	$( "#something" ).val( "something" );
+
+	// Validate the form
+	v.form();
+	errors( 1, "Validate manualy" );
+
+	// Check for special keys
+	e.val( "aaa" );
+	$.each( excludedKeys, function( key, keyCode ) {
+		triggerEvent( e, keyCode );
+		errors( 1, key + " key" );
+	});
+
+	// Normal keyup
+	e.val( "aaaaa" );
+	e.trigger( "keyup" );
+	errors( 0, "Normal keyup" );
+});
+
 test( "validate checkbox on click", function() {
 	function errors( expected, message ) {
 		equal( expected, v.size(), message );


### PR DESCRIPTION
Avoid revalidate the field when pressing one of the following keys in `onkeyup` method:
```
	Shift           => 16
	Alt             => 18
	Caps lock       => 20
	End             => 35
	Home            => 36
	Left arrow      => 37
	Up arrow        => 38
	Right arrow     => 39
	Down arrow      => 40
	Insert          => 45
	Num lock        => 144
	AltGr key       => 225
```