### PR TITLE
Add stopPropagation setting

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -80,6 +80,10 @@ $.extend($.fn, {
 					}
 					return handle();
 				} else {
+				        if ( validator.settings.stopPropagation ) {
+				          // don't bubble submit request
+				          event.stopImmediatePropagation();
+				        }
 					validator.focusInvalid();
 					return false;
 				}
@@ -240,6 +244,7 @@ $.extend( $.validator, {
 		errorContainer: $( [] ),
 		errorLabelContainer: $( [] ),
 		onsubmit: true,
+		stopPropagation: false,
 		ignore: ":hidden",
 		ignoreTitle: false,
 		onfocusin: function( element ) {


### PR DESCRIPTION
When integrating with other JS libraries, such as those that do Ajax requests on form submit, we want to make sure that the form does not actually get submitted when it is invalid. We do this by calling ``stopImmediatePropagation()`` on the event when this setting is true. This stops all other listeners from getting the submit event and therefore the form is not submitted.