### PR TITLE
Add support for contentEditable tags

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -555,14 +555,14 @@ $.extend( $.validator, {
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
-				var name = this.name || $( this ).attr("name"); // for contenteditable
+				var name = this.name || $( this ).attr( "name" ); // for contenteditable
 				if ( !name && validator.settings.debug && window.console ) {
 					console.error( "%o has no name assigned", this );
 				}
 
 				// set form expando on contenteditable
-				if (this.hasAttribute("contenteditable")) {
-					this.form = $(this).closest("form")[0];
+				if ( this.hasAttribute( "contenteditable" ) ) {
+					this.form = $( this ).closest( "form" )[0];
 				}
 
 				// select only the first element for each name, and only those with rules specified
@@ -614,7 +614,7 @@ $.extend( $.validator, {
 				return element.validity.badInput ? false : $element.val();
 			}
 
-			if (element.hasAttribute( "contenteditable" )) {
+			if ( element.hasAttribute( "contenteditable" ) ) {
 				val = $element.text();
 			} else {
 				val = $element.val();

--- a/src/core.js
+++ b/src/core.js
@@ -555,16 +555,22 @@ $.extend( $.validator, {
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
-				if ( !this.name && validator.settings.debug && window.console ) {
+			    var name = this.name || $(this).attr("name"); // for contenteditable
+				if ( !name && validator.settings.debug && window.console ) {
 					console.error( "%o has no name assigned", this );
 				}
 
+			    // set form expando on contenteditable
+				if (this.hasAttribute("contenteditable")) {
+					this.form = $(this).closest("form")[0];
+				}
+
 				// select only the first element for each name, and only those with rules specified
-				if ( this.name in rulesCache || !validator.objectLength( $( this ).rules() ) ) {
+				if ( name in rulesCache || !validator.objectLength( $( this ).rules() ) ) {
 					return false;
 				}
 
-				rulesCache[ this.name ] = true;
+				rulesCache[ name ] = true;
 				return true;
 			} );
 		},
@@ -608,10 +614,9 @@ $.extend( $.validator, {
 				return element.validity.badInput ? false : $element.val();
 			}
 
-			if (element.hasAttribute('contenteditable')) {
+			if (element.hasAttribute("contenteditable")) {
 			        val = $element.text();
-			}
-			else {
+			} else {
 				val = $element.val();
 			}
 			if ( typeof val === "string" ) {

--- a/src/core.js
+++ b/src/core.js
@@ -369,7 +369,7 @@ $.extend( $.validator, {
 					":text, [type='password'], [type='file'], select, textarea, [type='number'], [type='search'], " +
 					"[type='tel'], [type='url'], [type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], [type='range'], [type='color'], " +
-					"[type='radio'], [type='checkbox']", delegate)
+					"[type='radio'], [type='checkbox'], [contenteditable]", delegate)
 				// Support: Chrome, oldIE
 				// "select" is provided as event.target when clicking a option
 				.on("click.validate", "select, option, [type='radio'], [type='checkbox']", delegate);
@@ -551,7 +551,7 @@ $.extend( $.validator, {
 
 			// select all valid inputs inside the form (no submit or reset buttons)
 			return $( this.currentForm )
-			.find( "input, select, textarea" )
+			.find( "input, select, textarea, [contenteditable]" )
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
@@ -608,7 +608,12 @@ $.extend( $.validator, {
 				return element.validity.badInput ? false : $element.val();
 			}
 
-			val = $element.val();
+			if (element.hasAttribute('contenteditable')) {
+			        val = $element.text();
+			}
+			else {
+				val = $element.val();
+			}
 			if ( typeof val === "string" ) {
 				return val.replace( /\r/g, "" );
 			}

--- a/src/core.js
+++ b/src/core.js
@@ -555,12 +555,12 @@ $.extend( $.validator, {
 			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
-			    var name = this.name || $(this).attr("name"); // for contenteditable
+				var name = this.name || $( this ).attr("name"); // for contenteditable
 				if ( !name && validator.settings.debug && window.console ) {
 					console.error( "%o has no name assigned", this );
 				}
 
-			    // set form expando on contenteditable
+				// set form expando on contenteditable
 				if (this.hasAttribute("contenteditable")) {
 					this.form = $(this).closest("form")[0];
 				}
@@ -614,8 +614,8 @@ $.extend( $.validator, {
 				return element.validity.badInput ? false : $element.val();
 			}
 
-			if (element.hasAttribute("contenteditable")) {
-			        val = $element.text();
+			if (element.hasAttribute( "contenteditable" )) {
+				val = $element.text();
 			} else {
 				val = $element.val();
 			}

--- a/test/index.html
+++ b/test/index.html
@@ -383,11 +383,11 @@
 		<input type="text" name="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~" id="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~" required minlength="15">
 	</form>
 	<form id="contenteditableForm">
-	  <div contenteditable id="contenteditableNumberInvalid" data-rule-number="true" name="field1">ABC</div>
-	  <div contenteditable id="contenteditableNumberValid" data-rule-number="true" name="field2">123</div>
-	  <div contenteditable id="contenteditableRequiredInvalid" data-rule-required="true" name="field3"></div>
-	  <div contenteditable id="contenteditableRequiredValid" data-rule-required="true" name="field3">Some text</div>
-	  <input id="contenteditableInput" type="text" data-rule-number="true" name="field4" value="ABC" />
+		<div contenteditable id="contenteditableNumberInvalid" data-rule-number="true" name="field1">ABC</div>
+		<div contenteditable id="contenteditableNumberValid" data-rule-number="true" name="field2">123</div>
+		<div contenteditable id="contenteditableRequiredInvalid" data-rule-required="true" name="field3"></div>
+		<div contenteditable id="contenteditableRequiredValid" data-rule-required="true" name="field3">Some text</div>
+		<input id="contenteditableInput" type="text" data-rule-number="true" name="field4" value="ABC" />
 	</form>
 </div>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -382,6 +382,13 @@
 		<label for="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~">Input text</label>
 		<input type="text" name="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~" id="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~" required minlength="15">
 	</form>
+	<form id="contenteditableForm">
+	  <div contenteditable id="contenteditableNumberInvalid" data-rule-number="true" name="field1">ABC</div>
+	  <div contenteditable id="contenteditableNumberValid" data-rule-number="true" name="field2">123</div>
+	  <div contenteditable id="contenteditableRequiredInvalid" data-rule-required="true" name="field3"></div>
+	  <div contenteditable id="contenteditableRequiredValid" data-rule-required="true" name="field3">Some text</div>
+	  <input id="contenteditableInput" type="text" data-rule-number="true" name="field4" value="ABC" />
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -932,7 +932,7 @@ test( "works on contenteditable fields", function( assert ) {
 	var form = $( "#contenteditableForm" );
 	form.valid();
 	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );
-	assert.hasError( $( "#contenteditableRequiredInvalid" ) , "This field is required." );
+	assert.hasError( $( "#contenteditableRequiredInvalid" ), "This field is required." );
 	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
 	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
 	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );

--- a/test/test.js
+++ b/test/test.js
@@ -928,14 +928,14 @@ test( "bypassing validation on form submission", function() {
 	equal( $v.numberOfInvalids(), 1, "Validation failed correctly" );
 } );
 
-test( "works on contenteditable fields", function(assert) {
+test( "works on contenteditable fields", function( assert ) {
 	var form = $( "#contenteditableForm" );
 	form.valid();
-	assert.hasError($("#contenteditableNumberInvalid"), "Please enter a valid number.");
-	assert.hasError($("#contenteditableRequiredInvalid"), "This field is required.");
-	assert.hasError($("#contenteditableInput"), "Please enter a valid number.");
-	assert.noErrorFor($("#contenteditableNumberValid"));
-	assert.noErrorFor($("#contenteditableRequiredValid"));
+	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );
+	assert.hasError( $( "#contenteditableRequiredInvalid") , "This field is required." );
+	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
+	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
+	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );
 });
 
 module( "misc" );

--- a/test/test.js
+++ b/test/test.js
@@ -932,7 +932,7 @@ test( "works on contenteditable fields", function( assert ) {
 	var form = $( "#contenteditableForm" );
 	form.valid();
 	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );
-	assert.hasError( $( "#contenteditableRequiredInvalid") , "This field is required." );
+	assert.hasError( $( "#contenteditableRequiredInvalid" ) , "This field is required." );
 	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
 	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
 	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );

--- a/test/test.js
+++ b/test/test.js
@@ -928,6 +928,16 @@ test( "bypassing validation on form submission", function() {
 	equal( $v.numberOfInvalids(), 1, "Validation failed correctly" );
 } );
 
+test( "works on contenteditable fields", function(assert) {
+	var form = $( "#contenteditableForm" );
+	form.valid();
+	assert.hasError($('#contenteditableNumberInvalid'), 'Please enter a valid number.');
+	assert.hasError($('#contenteditableRequiredInvalid'), 'This field is required.');
+	assert.hasError($('#contenteditableInput'), 'Please enter a valid number.');
+	assert.noErrorFor($('#contenteditableNumberValid'));
+	assert.noErrorFor($('#contenteditableRequiredValid'));
+});
+
 module( "misc" );
 
 test( "success option", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -931,11 +931,11 @@ test( "bypassing validation on form submission", function() {
 test( "works on contenteditable fields", function(assert) {
 	var form = $( "#contenteditableForm" );
 	form.valid();
-	assert.hasError($('#contenteditableNumberInvalid'), 'Please enter a valid number.');
-	assert.hasError($('#contenteditableRequiredInvalid'), 'This field is required.');
-	assert.hasError($('#contenteditableInput'), 'Please enter a valid number.');
-	assert.noErrorFor($('#contenteditableNumberValid'));
-	assert.noErrorFor($('#contenteditableRequiredValid'));
+	assert.hasError($("#contenteditableNumberInvalid"), "Please enter a valid number.");
+	assert.hasError($("#contenteditableRequiredInvalid"), "This field is required.");
+	assert.hasError($("#contenteditableInput"), "Please enter a valid number.");
+	assert.noErrorFor($("#contenteditableNumberValid"));
+	assert.noErrorFor($("#contenteditableRequiredValid"));
 });
 
 module( "misc" );


### PR DESCRIPTION
Currently the validation library only works on classic form elements. However, there is no reason it can't work on rich text elements that have names and use contentEditable. This change adds support for these tags.