### PR TITLE
Methods: Fixed values comparision in min/max

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1239,12 +1239,12 @@ $.extend( $.validator, {
 
 		// http://jqueryvalidation.org/min-method/
 		min: function( value, element, param ) {
-			return this.optional( element ) || value >= param;
+			return this.optional( element ) || parseInt(value, 10) >= param;
 		},
 
 		// http://jqueryvalidation.org/max-method/
 		max: function( value, element, param ) {
-			return this.optional( element ) || value <= param;
+			return this.optional( element ) || parseInt(value, 10) <= param;
 		},
 
 		// http://jqueryvalidation.org/range-method/


### PR DESCRIPTION
Hello,

Recently I have a problem with these methods mixed up with custom numbers filter, and it occurs that value in my case was type of string. I thought it will be good to make sure our compared value is parsed to int - taking into account js types complexity and lack of localized number rules in plugin.

Let me know what you think. Cheers.