### PR TITLE
Reentrancy issue with remote method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1274,6 +1274,11 @@ $.extend( $.validator, {
 			var previous = this.previousValue( element ),
 				validator, data;
 
+                        // execute guard before pushing this.settings.messages
+                        if ( previous.old === value ) {
+				return previous.valid;
+			}
+			
 			if (!this.settings.messages[ element.name ] ) {
 				this.settings.messages[ element.name ] = {};
 			}
@@ -1281,10 +1286,6 @@ $.extend( $.validator, {
 			this.settings.messages[ element.name ].remote = previous.message;
 
 			param = typeof param === "string" && { url: param } || param;
-
-			if ( previous.old === value ) {
-				return previous.valid;
-			}
 
 			previous.old = value;
 			validator = this;
@@ -1312,8 +1313,9 @@ $.extend( $.validator, {
 						validator.showErrors();
 					} else {
 						errors = {};
-						message = response || validator.defaultMessage( element, "remote" );
-						errors[ element.name ] = previous.message = $.isFunction( message ) ? message( value ) : message;
+						previous.message = validator.defaultMessage( element, "remote" );
+						message = response || previous.message
+						errors[ element.name ] = $.isFunction( message ) ? message( value ) : message;
 						validator.invalid[ element.name ] = true;
 						validator.showErrors( errors );
 					}


### PR DESCRIPTION
While testing a custom variant of the remote method i found that I had to move up this guard otherwise `previous.originalMessage` would get stomped on a reentrant invocation.  To be clear, I haven't confirmed this using the `remote` method directly but I am using all the same boilerplate and just changing my method name (and some details about how the response is handled).
Also I believe `previous.message` should not be getting assigned a resolved value in the case it's a function, otherwise it will always remain that static value instead of dynamically updating on the next error.
I figured it was worth mentioning.