### PR TITLE
Allow "accept" filetype validation to contain a blank among the accepted MIME types

### DIFF
--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -19,7 +19,7 @@ $.validator.addMethod("accept", function(value, element, param) {
 		if (typeParam.match(/^\|/) || typeParam.match(/\|\|/) || typeParam.match(/\|$/)) {
 			blankTypeAllowed = true;
 			// remove the error-prone blank entry from regex before continuing.
-			typeParam = typeParam.replace(/^\|/, "").replace(/\|\|/g, "|");
+			typeParam = typeParam.replace(/^\|/, "").replace(/\|\|/g, "|").replace(/\|$/, "");
 		}
 
 		// Check if the element has a FileList before checking each file

--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -3,6 +3,7 @@ $.validator.addMethod("accept", function(value, element, param) {
 	// Split mime on commas in case we have multiple types we can accept
 	var typeParam = typeof param === "string" ? param.replace(/\s/g, "").replace(/,/g, "|") : "image/*",
 	optionalValue = this.optional(element),
+	blankTypeAllowed = false,
 	i, file;
 
 	// Element is optional
@@ -15,7 +16,6 @@ $.validator.addMethod("accept", function(value, element, param) {
 		typeParam = typeParam.replace(/\*/g, ".*");
 
 		// Allow checking for BLANK mimetype.
-		var blankTypeAllowed = false;
 		if (typeParam.match(/^\|/) || typeParam.match(/\|\|/)) {
 			blankTypeAllowed = true;
 			// remove the error-prone blank entry from regex before continuing.

--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -16,7 +16,7 @@ $.validator.addMethod("accept", function(value, element, param) {
 		typeParam = typeParam.replace(/\*/g, ".*");
 
 		// Allow checking for BLANK mimetype.
-		if (typeParam.match(/^\|/) || typeParam.match(/\|\|/)) {
+		if (typeParam.match(/^\|/) || typeParam.match(/\|\|/) || typeParam.match(/\|$/)) {
 			blankTypeAllowed = true;
 			// remove the error-prone blank entry from regex before continuing.
 			typeParam = typeParam.replace(/^\|/, "").replace(/\|\|/g, "|");

--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -28,7 +28,7 @@ $.validator.addMethod("accept", function(value, element, param) {
 				file = element.files[i];
 
 				// Allow blank mimetype if regex contained an empty entry.
-				if (file.type == "" && blankTypeAllowed) {
+				if (file.type === "" && blankTypeAllowed) {
 					continue;  // skip the regex check
 				}
 

--- a/src/additional/accept.js
+++ b/src/additional/accept.js
@@ -14,10 +14,23 @@ $.validator.addMethod("accept", function(value, element, param) {
 		// If we are using a wildcard, make it regex friendly
 		typeParam = typeParam.replace(/\*/g, ".*");
 
+		// Allow checking for BLANK mimetype.
+		var blankTypeAllowed = false;
+		if (typeParam.match(/^\|/) || typeParam.match(/\|\|/)) {
+			blankTypeAllowed = true;
+			// remove the error-prone blank entry from regex before continuing.
+			typeParam = typeParam.replace(/^\|/, "").replace(/\|\|/g, "|");
+		}
+
 		// Check if the element has a FileList before checking each file
 		if (element.files && element.files.length) {
 			for (i = 0; i < element.files.length; i++) {
 				file = element.files[i];
+
+				// Allow blank mimetype if regex contained an empty entry.
+				if (file.type == "" && blankTypeAllowed) {
+					continue;  // skip the regex check
+				}
 
 				// Grab the mimetype from the loaded file, verify it matches
 				if (!file.type.match(new RegExp( ".?(" + typeParam + ")$", "i"))) {


### PR DESCRIPTION
The backstory on this change is that on the Windows platform, if you install WinRAR (or WinZip or 7Zip), those tools will very often screw up the extension-to-mimetype mapping of the OS, so the file object's .type has an EMPTY STRING value when it gets here for validation.

The intuitive thing to do is support EMPTY STRING by just putting a comma prefix on the accept value, such as "accept=',application/zip,application/x-zip-compressed'".  But unfortunately that turns the regex into a mess that will accept ANY type.

This patch handles the case of a blank "accept" type before RegExp has to.

(Also, the RegExp has a period where I think a "\\." should be, but I made that change in a separate pull req since it's unlikely to be controversial, whereas this one may raise some eyebrows and require further discussion).