### PR TITLE
fix #1457 Name of the checkbox and radio xxx[] can not work normally

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -767,7 +767,7 @@ $.extend( $.validator, {
 		showLabel: function( element, message ) {
 			var place, group, errorID,
 				error = this.errorsFor( element ),
-				elementID = this.idOrName( element ),
+				elementID = this.idOrName( element ).replace(/\[\]/g,"-"),
 				describedBy = $( element ).attr( "aria-describedby" );
 			if ( error.length ) {
 				// refresh error/success class
@@ -838,7 +838,7 @@ $.extend( $.validator, {
 		},
 
 		errorsFor: function( element ) {
-			var name = this.idOrName( element ),
+			var name = this.idOrName( element ).replace(/\[\]/g,"-"),
 				describer = $( element ).attr( "aria-describedby" ),
 				selector = "label[for='" + name + "'], label[for='" + name + "'] *";
 

--- a/src/core.js
+++ b/src/core.js
@@ -767,7 +767,7 @@ $.extend( $.validator, {
 		showLabel: function( element, message ) {
 			var place, group, errorID,
 				error = this.errorsFor( element ),
-				elementID = this.idOrName( element ).replace(/\[\]/g,"-"),
+				elementID = this.idOrName( element ).replace( /\[\]/g, "-" ),
 				describedBy = $( element ).attr( "aria-describedby" );
 			if ( error.length ) {
 				// refresh error/success class
@@ -838,7 +838,7 @@ $.extend( $.validator, {
 		},
 
 		errorsFor: function( element ) {
-			var name = this.idOrName( element ).replace(/\[\]/g,"-"),
+			var name = this.idOrName( element ).replace( /\[\]/g, "-" ),
 				describer = $( element ).attr( "aria-describedby" ),
 				selector = "label[for='" + name + "'], label[for='" + name + "'] *";
 

--- a/test/index.html
+++ b/test/index.html
@@ -370,6 +370,14 @@
 		<input id="radiocheckbox-1-2" autocomplete="off" type="checkbox" name="radiocheckbox-1" required="required">
 		<input id="radiocheckbox-1-3" autocomplete="off" type="checkbox" name="radiocheckbox-1" required="required">
 	</form>
+	<form id="radiocheckbox_array">
+		<input id="radio_array_1" type="radio" value="1" name="radio_array[]" required="true">
+		<input id="radio_array_2" type="radio" value="2" name="radio_array[]" required="true">
+		<input id="radio_array_3" type="radio" value="3" name="radio_array[]" required="true">
+		<input id="checkbox_array_1" type="checkbox" value="1" name="checkbox_array[]" required="true" minlength=2>
+		<input id="checkbox_array_2" type="checkbox" value="2" name="checkbox_array[]" required="true" minlength=2>
+		<input id="checkbox_array_3" type="checkbox" value="3" name="checkbox_array[]" required="true" minlength=2>
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -217,6 +217,18 @@ test( "form(): radio buttons: required", function() {
 	equal($( "#testForm10Radio2" ).attr( "class" ), "valid" );
 });
 
+test( "form(): radiocheckbox_array", function() {
+	expect( 3 );
+	var form = $( "#radiocheckbox_array" )[ 0 ],
+		v = $( form ).validate();
+	ok( !v.form(), "Invalid Form" );
+
+	$( "#radio_array_1, #checkbox_array_1" ).attr( "checked", true );
+	ok( !v.form(), "Invalid Form" );
+	$( "#checkbox_array_2" ).attr( "checked", true );
+	ok( v.form(), "Valid form" );
+});
+
 test( "form(): selects: min/required", function() {
 	expect( 3 );
 	var form = $( "#testForm7" )[ 0 ],


### PR DESCRIPTION
```
<input type="checkbox" name="ids[]"  id="ids_1" value="1" required="true" minlength=1>
<input type="checkbox" name="ids[]"  id="ids_2" value="2" required="true" minlength=1>
```
valid runtime error: Error: Syntax error, unrecognized expression: #ids[]-error

The cause of the error elements ID name has invalid characters
```
		showLabel: function( element, message ) {
			var place, group, errorID,
				error = this.errorsFor( element ),
				elementID = this.idOrName( element ),
				describedBy = $( element ).attr( "aria-describedby" );
			if ( error.length ) {
				// refresh error/success class
				error.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
				// replace message on existing label
				error.html( message );
			} else {
				// create error element
				error = $( "<" + this.settings.errorElement + ">" )
					.attr( "id", elementID + "-error" )
					.addClass( this.settings.errorClass )
					.html( message || "" );
```

see #1457 