### PR TITLE
Cast NaN value attributes to undefined for Opera Mini

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -999,6 +999,10 @@ $.extend( $.validator, {
 			// allows type="date" and others to be compared as strings
 			if ( /min|max/.test( method ) && ( type === null || /number|range|text/.test( type ) ) ) {
 				value = Number( value );
+				if (isNaN(value))
+				{
+					value = undefined;
+				}
 			}
 
 			if ( value || value === 0 ) {


### PR DESCRIPTION
Opera Mini failed to validate fields with no `minlength` attribute specified producing error messages such as:

> Please enter at least NaN characters.

Setting `NaN` values to `undefined` fixes the problem.