### PR TITLE
Descendants of a disabled fieldset are not ignored

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -550,7 +550,7 @@ $.extend( $.validator, {
 			// select all valid inputs inside the form (no submit or reset buttons)
 			return $( this.currentForm )
 			.find( "input, select, textarea" )
-			.not( ":submit, :reset, :image, [disabled]" )
+			.not( ":submit, :reset, :image, :disabled" )
 			.not( this.settings.ignore )
 			.filter( function() {
 				if ( !this.name && validator.settings.debug && window.console ) {


### PR DESCRIPTION
Hi,

Change in [line 553](https://github.com/jzaefferer/jquery-validation/blob/master/src/core.js#L553):

Substituted `[disabled]` with `:disabled`, this is crucial, because `[disabled]` doesn't affect fields that are under a disabled `fieldset`.

Currently the embedded input bellow is being validated, because it doesn't fulfil `[disabled]`.
It does however return `true` for `$('#disabled').is(':disabled')`, hence the reason of my change.

    <fieldset disabled="disabled">
      <input id="disabled" type="text" />
    </fieldset>

And as a workaround, until this issue is fixed, `ignore: ":hidden, fieldset[disabled] *"` can be used.