### PR TITLE
Added support for testing whether response from server is valid rather t...

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1299,8 +1299,10 @@ $.extend( $.validator, {
 				data: data,
 				context: validator.currentForm,
 				success: function( response ) {
-					var valid = response === true || response === "true",
-						errors, message, submitted;
+                    var valid = (typeof param.validateResponse === 'function' && param.validateResponse(element, response))
+                            || response === true
+                            || response === "true",
+                        errors, message, submitted;
 
 					validator.settings.messages[ element.name ].remote = previous.originalMessage;
 					if ( valid ) {


### PR DESCRIPTION
Added a new parameter `validateResponse` which can be used to determine if a server response is valid or not. Currently only "true" is considered valid, so this change is useful for using an existing web service that responds with something other than "true".