### PR TITLE
Package: Adding build script to npm package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		}
 	],
 	"scripts": {
+		"build": "npm install && grunt",
 		"test": "grunt",
 		"prepublish": "grunt"
 	},


### PR DESCRIPTION
Adding build script to package.json, this way when the package is imported through npm, it is ready to use.