### PR TITLE
Feature: Make remote complete function more useful

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1299,6 +1299,9 @@ $.extend( $.validator, {
 				data: data,
 				context: validator.currentForm,
 				success: function( response ) {
+					if (typeof response === 'object' && 'valid' in response) {
+						response = response['valid'] === true || response['valid'] === "true";
+					}
 					var valid = response === true || response === "true",
 						errors, message, submitted;
 


### PR DESCRIPTION
Added an option to remote rule to send more data from server than just valid status and error message.

This feature is backwards compatible, meaning everything will still work without changing your code but now you could make it more advanced if your server response is this...

Server json response:
```javascript
{
    valid: true,
    whatever: 'my random data'
}
```

Feature request #1491 