### PR TITLE
Tests: Dropped obsolete timeouts, speeding up test runtime.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -389,7 +389,7 @@ asyncTest("validation triggered on radio/checkbox when using keyboard", function
 		// assert all event handlers fired
 		equal(6, triggeredEvents);
 		start();
-	}, 50);
+	});
 });
 
 asyncTest("validation triggered on radio/checkbox when using mouseclick", function() {
@@ -420,7 +420,7 @@ asyncTest("validation triggered on radio/checkbox when using mouseclick", functi
 		// assert all event handlers fired
 		equal(2, triggeredEvents);
 		start();
-	}, 50);
+	});
 });
 
 test( "showErrors()", function() {


### PR DESCRIPTION
As the diff might already convey, this change drops running the testsuite by ~100ms.

Confirmed this guess by running the testsuite locally on Windows7x64 and
- Chrome 44.0.2403.30
- IE11.0
- FF40.0a2 (Current Dev Edition)

In IE11 test fails, but this already failed on my workstation before this PR:
- focusInvalid

> Expected at least one assertion, but none were run - call expect(0) to accept zero assertions.@ 47 
> msSource:     at Global code (http://localhost:8000/jquery-validation/test/test.js:709:1)
 
Closes #1343.