### PR TITLE
added license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"description": "Client-side form validation made easy",
 	"version": "1.13.2-pre",
 	"homepage": "http://jqueryvalidation.org/",
+	"license": "MIT",
 	"author": {
 		"name": "Jörn Zaefferer",
 		"email": "joern.zaefferer@gmail.com",


### PR DESCRIPTION
This fixes a warning while `npm install` that the package does not provide license information

>npm WARN package.json jquery-validation@1.13.2-pre No license field.