### PR TITLE
Additionals: Added maxsize plugin

### DIFF
--- a/src/additional/maxsize.js
+++ b/src/additional/maxsize.js
@@ -1,0 +1,30 @@
+// Require a file at/under a given size
+// Usage: `{rules: {file: {maxsize: 5 * 1024 * 1024 /* 5MB */}}}`
+$.validator.addMethod("maxsize", function(value, element, param) {
+  // If the value is optional, return it
+  var maxSize = param,
+      optionalValue = this.optional(element),
+      i, len, file;
+  if (optionalValue) {
+    return optionalValue;
+  }
+
+  // If the element is a file, then verify the size is at most what we expect
+  if ($(element).attr("type") === "file") {
+    // If we are in a browser that supports FileList, then check the files
+    if (element.files && element.files.length) {
+      i = 0;
+      len = element.files.length;
+      for (; i < len; i++) {
+        file = element.files[i];
+        // `file.size` is size in bytes
+        if (file.size > maxSize) {
+          return false;
+        }
+      }
+    }
+  }
+
+  // Return success (either we don't have access to files due to older browser or files looked good)
+  return true;
+}, $.validator.format("Please submit a file that is under the maximum size."));


### PR DESCRIPTION
We recently created a maxsize plugin to detect that a file is too large before submission. Based off of #450 and #1111, it looks like other people would like it as well. In this PR:

- Added maxsize plugin into `src/additional`

**Missing:**

We didn't add any tests as there are no tests for the only other `FileList` based plugin (`accept.js`). I am assuming that the reason for this is we cannot programmatically tell a browser where to get our file uploads from.