### PR TITLE
Speedup travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js:
   - 0.10
+
+cache:
+  - npm
+sudo: false
+
 install:
   - npm install grunt-cli -g
   - npm install


### PR DESCRIPTION
Activate the faster travis infrastructure and activate caching for npm dependencies between builds.

Speedup does not necessarily mean per build time, but also shorter waiting times in build queues.