### PR TITLE
Stricter email validation

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1167,7 +1167,7 @@ $.extend( $.validator, {
 			// Retrieved 2014-01-14
 			// If you have a problem with this implementation, report a bug against the above spec
 			// Or use custom methods to implement your own email validation
-			return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/.test( value );
+			return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-.]{0,61}[a-zA-Z0-9])?\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/.test( value );
 		},
 
 		// http://jqueryvalidation.org/url-method/


### PR DESCRIPTION
Actually the email validator consider optional a second domain level, but I really doesn't know of any email of this kind, hence I think it will be more pragmatical to make it required.

With this edit:
```
email@domain        -> invalid
email@domain.com    -> valid
email@domin.a.b.com -> valid
```