### PR TITLE
Core: Allow 'false' as value when overriding rules

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1059,7 +1059,7 @@ $.extend( $.validator, {
 		// handle dependency check
 		$.each( rules, function( prop, val ) {
 			// ignore rule when param is explicitly false, eg. required:false
-			if ( val === false ) {
+			if ( val === false || val === "false" ) {
 				delete rules[ prop ];
 				return;
 			}

--- a/test/index.html
+++ b/test/index.html
@@ -71,6 +71,9 @@
 		<label id="errorFirstnamec" for="firstnamec" class="error">error for firstname</label>
 		<input title="buga" name="lastname" id="lastnamec">
 		<input name="username" id="usernamec">
+		<input type="text" name="year" id="yeara" data-rule-required="false">
+		<input type="text" name="month" id="montha" date="false">
+		<input type="text" name="month" id="monthb" class="date" date="false">
 	</form>
 	<form id="userForm">
 		<input type="text" data-rule-required="true" name="username" id="username">

--- a/test/rules.js
+++ b/test/rules.js
@@ -20,6 +20,24 @@ test("rules(), ignore method:false", function() {
 	deepEqual( element.rules(), { minlength: 2 } );
 });
 
+test("rules(), ignore explicit method:false", function() {
+	var element_without_required = $("#yeara"),
+		element_without_date  = $("#montha");
+
+	$("#testForm1clean").validate();
+
+	deepEqual( element_without_required.rules(), {} );
+	deepEqual( element_without_date.rules(), {} );
+});
+
+test("rules(), override class rules by explicit attribute with false", function() {
+	var element_without_date  = $("#monthb");
+
+	$("#testForm1clean").validate();
+
+	deepEqual( element_without_date.rules(), {} );
+});
+
 test("rules() HTML5 required (no value)", function() {
 	var element = $("#testForm11text1");
 


### PR DESCRIPTION
This PR enables ability to deny or override rules via declarative HTML attributes (as it done for rules defined in `.validate` method).