### PR TITLE
Additionals: Updates to postalCodeCA method

### DIFF
--- a/src/additional/postalCodeCA.js
+++ b/src/additional/postalCodeCA.js
@@ -12,5 +12,5 @@
  * @cat Plugins/Validate/Methods
  */
 $.validator.addMethod( "postalCodeCA", function( value, element ) {
-	return this.optional( element ) || /^[ABCEGHJKLMNPRSTVXY]\d[A-Z] *\d[A-Z]\d$/i.test( value );
+	return this.optional( element ) || /^[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ] *\d[ABCEGHJKLMNPRSTVWXYZ]\d$/i.test( value );
 }, "Please specify a valid postal code" );

--- a/src/additional/postalCodeCA.js
+++ b/src/additional/postalCodeCA.js
@@ -12,5 +12,5 @@
  * @cat Plugins/Validate/Methods
  */
 $.validator.addMethod( "postalCodeCA", function( value, element ) {
-	return this.optional( element ) || /^[ABCEGHJKLMNPRSTVXY]\d[A-Z] \d[A-Z]\d$/.test( value );
+	return this.optional( element ) || /^[ABCEGHJKLMNPRSTVXY]\d[A-Z] *\d[A-Z]\d$/i.test( value );
 }, "Please specify a valid postal code" );

--- a/test/methods.js
+++ b/test/methods.js
@@ -1181,12 +1181,14 @@ test("currency", function() { // Works with any symbol
 
 test("postalCodeCA", function() {
 	var method = methodTest("postalCodeCA");
-	ok( method( "H0H 0H0"), "Valid CA Postal Code; Single space" );
-	ok( !method( "H0H0H0"), "Inalid CA Postal Code; No space" );
-	ok( !method( "H0H-0H0"), "Invalid CA Postal Code; Single dash" );
-	ok( !method( "H0H 0H"), "Invalid CA Postal Code; Too Short" );
-	ok( !method( "Z0H 0H"), "Invalid CA Postal Code; Only 'ABCEGHJKLMNPRSTVXY' are valid starting characters" );
-	ok( !method( "h0h 0h0"), "Invalid CA Postal Code; Only upper case characters" );
+	ok( method( "H0H0H0"), "Valid Canadian postal code: all upper case with no space" );
+	ok( method( "H0H 0H0"), "Valid Canadian postal code: all upper case with one space" );
+	ok( method( "H0H  0H0"), "Valid Canadian postal code: all upper case with multiple spaces" );
+	ok( method( "h0h 0h0"), "Valid Canadian postal code: all lower case with space" );
+	ok( method( "h0h0h0" ), "Valid Canadian postal code: all lower case with no space" );
+	ok( !method( "H0H-0H0"), "Invalid Canadian postal code: dash used as separator" );
+	ok( !method( "H0H 0H"), "Invalid Canadian postal code: too short" );
+	ok( !method( "Z0H 0H"), "Invalid Canadian postal code: only 'ABCEGHJKLMNPRSTVXY' are valid starting characters" );
 });
 
 test("stateUS", function() {

--- a/test/methods.js
+++ b/test/methods.js
@@ -1188,7 +1188,9 @@ test("postalCodeCA", function() {
 	ok( method( "h0h0h0" ), "Valid Canadian postal code: all lower case with no space" );
 	ok( !method( "H0H-0H0"), "Invalid Canadian postal code: dash used as separator" );
 	ok( !method( "H0H 0H"), "Invalid Canadian postal code: too short" );
-	ok( !method( "Z0H 0H"), "Invalid Canadian postal code: only 'ABCEGHJKLMNPRSTVXY' are valid starting characters" );
+	ok( !method( "Z0H 0H0"), "Invalid Canadian postal code: only 'ABCEGHJKLMNPRSTVXY' are valid first characters for the Forward Sorting Area" );
+	ok( !method( "H0D 0H0"), "Invalid Canadian postal code: only 'ABCEGHJKLMNPRSTVWXYZ' are valid third characters for the Forward Sorting Area" );
+	ok( !method( "H0H 0D0"), "Invalid Canadian postal code: only 'ABCEGHJKLMNPRSTVWXYZ' are valid second characters for the Local Delivery Unit" );
 });
 
 test("stateUS", function() {


### PR DESCRIPTION
Allow both upper case and lower case characters and zero or more spaces between the Forward Sorting Area and Local Delivery Unit portions as users do not always use all upper case or include a space (see https://github.com/wet-boew/wet-boew/issues/6760).

Correct the regular expression to fail entries that include invalid characters D, F, I, O, Q, and U which are not used in Canadian postal codes (emphasis mine):
<blockquote>
<p>The postal codeOM is a six-character code defined and maintained by Canada Post Corporation (CPC) for the purpose of sorting and delivering mail. The characters are arranged in the form 'ANA NAN', where 'A' represents an alphabetic character and 'N' represents a numeric character (e.g., K1A 0T6). The postal codeOM uses 18 alphabetic characters and 10 numeric characters. <strong>Postal codes do not include the letters D, F, I, O, Q or U</strong>, and the first position also does not make use of the letters W or Z.</p>
<cite>-- <a href="http://www.statcan.gc.ca/pub/92-154-g/2015001/tech-eng.htm">Postal Code<sup>OM</sup> Conversion File (PCCF), Reference Guide</a></cite>
</blockquote>