### PR TITLE
case-insensitive check for BIC

### DIFF
--- a/src/additional/bic.js
+++ b/src/additional/bic.js
@@ -12,5 +12,5 @@
  * - Last 3 characters - branch code, optional (shall not start with 'X' except in case of 'XXX' for primary office) (letters and digits)
  */
 $.validator.addMethod("bic", function(value, element) {
-    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-2])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value );
+    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-2])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value.toUpperCase() );
 }, "Please specify a valid BIC code");

--- a/src/additional/bic.js
+++ b/src/additional/bic.js
@@ -2,7 +2,7 @@
  * BIC is the business identifier code (ISO 9362). This BIC check is not a guarantee for authenticity.
  *
  * BIC pattern: BBBBCCLLbbb (8 or 11 characters long; bbb is optional)
- * 
+ *
  * Validation is case-insensitive. Please make sure to normalize input yourself.
  *
  * BIC definition in detail:

--- a/src/additional/bic.js
+++ b/src/additional/bic.js
@@ -2,6 +2,8 @@
  * BIC is the business identifier code (ISO 9362). This BIC check is not a guarantee for authenticity.
  *
  * BIC pattern: BBBBCCLLbbb (8 or 11 characters long; bbb is optional)
+ * 
+ * Validation is case-insensitive. Please make sure to normalize input yourself.
  *
  * BIC definition in detail:
  * - First 4 characters - bank code (only letters)

--- a/src/additional/iban.js
+++ b/src/additional/iban.js
@@ -1,7 +1,7 @@
 /**
  * IBAN is the international bank account number.
  * It has a country - specific format, that is checked here too
- * 
+ *
  * Validation is case-insensitive. Please make sure to normalize input yourself.
  */
 $.validator.addMethod("iban", function(value, element) {

--- a/src/additional/iban.js
+++ b/src/additional/iban.js
@@ -1,6 +1,8 @@
 /**
  * IBAN is the international bank account number.
  * It has a country - specific format, that is checked here too
+ * 
+ * Validation is case-insensitive. Please make sure to normalize input yourself.
  */
 $.validator.addMethod("iban", function(value, element) {
 	// some quick simple tests to prevent needless work


### PR DESCRIPTION
I found no appearant reason why a BIC has to be all-upper, so allowing customers to enter it lowercase or mixed should be ok.
Furthermore, the IBAN-validation also is case-insensitive.