### PR TITLE
#1567 Instead of using validating field's value to skip api call, use the serialized data object of the request

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1291,7 +1291,7 @@ $.extend( $.validator, {
 			}
 
 			var previous = this.previousValue( element ),
-				validator, data;
+				validator, data, optionDataString;
 
 			if (!this.settings.messages[ element.name ] ) {
 				this.settings.messages[ element.name ] = {};
@@ -1300,12 +1300,12 @@ $.extend( $.validator, {
 			this.settings.messages[ element.name ].remote = previous.message;
 
 			param = typeof param === "string" && { url: param } || param;
-
-			if ( previous.old === value ) {
+			optionDataString = $.param( $.extend( { data: value }, param.data ) );
+			if (previous.old === optionDataString) {
 				return previous.valid;
 			}
 
-			previous.old = value;
+			previous.old = optionDataString;
 			validator = this;
 			this.startRequest( element );
 			data = {};

--- a/test/methods.js
+++ b/test/methods.js
@@ -470,6 +470,42 @@ asyncTest("remote extensions", function() {
 	strictEqual( v.element(e), true, "still invalid, because remote validation must block until it returns; dependency-mismatch considered as valid though" );
 });
 
+test("remote, data previous querystring", function() {
+	expect(4);
+	var change = true,
+		e = $("#username"),
+		v = $("#userForm").validate({
+			rules: {
+				username: {
+					required: true,
+					remote: {
+						url: "users.php",
+						type: "POST",
+						data: {
+							email: function() {
+								if ( change ) {
+									change = false;
+									return "email.com";
+								}
+								return "email2.com";
+							}
+						},
+						beforeSend: function(request, settings) {
+							if ( change ) {
+								deepEqual(settings.data, "username=asdf&email=email.com");
+							} else {
+								deepEqual(settings.data, "username=asdf&email=email2.com");
+							}
+						}
+					}
+				}
+			}
+		});
+	$("#username").val("asdf");
+	strictEqual( v.element(e), true, "new email value (email.com), new request; dependency-mismatch considered as valid though" );
+	strictEqual( v.element(e), true, "new email value (email2.com), new request; dependency-mismatch considered as valid though" );
+});
+
 module("additional methods");
 
 test("phone (us)", function() {


### PR DESCRIPTION
Fix for #1567 ; Instead of just using validating field's value to determine whether or not to skip the remote check, use the data of the request that would go to the endpoint, as this may affect the validation result.