### PR TITLE
Allow non-singleton usage.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -10,11 +10,14 @@ $.extend($.fn, {
 			return;
 		}
 
-		// check if a validator for this form was already created
-		var validator = $.data( this[ 0 ], "validator" );
-		if ( validator ) {
-			return validator;
-		}
+		// Allow non-singleton:- useful e.g. if you want to apply conditional validation to a form
+		if (!options || typeof options.singleton === 'undefined' || options.singleton === true) {
+			// check if a validator for this form was already created
+			var validator = $.data( this[ 0 ], "validator" );
+			if ( validator ) {
+				return validator;
+			}
+		};
 
 		// Add novalidate tag if HTML5.
 		this.attr( "novalidate", "novalidate" );


### PR DESCRIPTION
This is useful e.g. if you want to apply conditional validation to a form. Such as a form where parts are hidden (and thus should not be validated) under certain conditions . This is a backwards-compatible change which triggered by an option.

To make use of it just add the option: {singleton: false}. That way the object will be re-initialised on every validation call; thus allowing you to pass different options in with each call.