### PR TITLE
Adding mechanism for custom asynchronous validation methods

### DIFF
--- a/test/methods.js
+++ b/test/methods.js
@@ -389,13 +389,13 @@ asyncTest("remote", function() {
 
 	$(document).ajaxStop(function() {
 		$(document).unbind("ajaxStop");
-		equal( 1, v.size(), "There must be one error" );
-		equal( "Peter in use", v.errorList[0].message );
+		equal( v.size(), 1, "There must be one error" );
+		equal( v.errorList[0].message, "Peter in use" );
 
 		$(document).ajaxStop(function() {
 			$(document).unbind("ajaxStop");
-			equal( 1, v.size(), "There must be one error" );
-			equal( "Peter2 in use", v.errorList[0].message );
+			equal( v.size(), 1, "There must be one error" );
+			equal( v.errorList[0].message, "Peter2 in use" );
 			start();
 		});
 		e.val("Peter2");


### PR DESCRIPTION
Hi!

These are my changes that should enable any jquery-validation plugin users to create their own 'remote' validation method. This might be needed if jquery-validation plugin is to be used with backend that requires some additional authentication (tokens, passwords, etc.). generally, some non-standard AJAX communication. Example usage:

```javascript

myRemote: function( value, element, param ) {
			var data = {};
			data[ element.name ] = value;
			return this.callbackMethod(value, element, function(processResult) {
				$.ajax( {
					url: param,
					headers: {
						"Authentication": "MyToken"
					},
					dataType: "json",
					type: "post",
					data: data,
					success: function( response ) {
						processResult( response.status === "VALID", response.message );
					}
				} );
			}, data);
		}
     
```