### PR TITLE
Revert "Core: escape errorID only for use in the regex"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -796,11 +796,11 @@ $.extend( $.validator, {
 					// If the element is not a child of an associated label, then it's necessary
 					// to explicitly apply aria-describedby
 
-					errorID = error.attr( "id" );
+					errorID = error.attr( "id" ).replace( /(:|\.|\[|\]|\$)/g, "\\$1");
 					// Respect existing non-error aria-describedby
 					if ( !describedBy ) {
 						describedBy = errorID;
-					} else if ( !describedBy.match( new RegExp( "\\b" + (errorID.replace( /(:|\.|\[|\]|\$)/g, "\\$1")) + "\\b" ) ) ) {
+					} else if ( !describedBy.match( new RegExp( "\\b" + errorID + "\\b" ) ) ) {
 						// Add to end of list if not already present
 						describedBy += " " + errorID;
 					}


### PR DESCRIPTION
This reverts commit b2df81ccb6276a6a39661ebd1ddd4a54c182217e.