### PR TITLE
Improving pt_BR translation and fixing a typo on the 'cifES' key.

### DIFF
--- a/src/localization/messages_pt_BR.js
+++ b/src/localization/messages_pt_BR.js
@@ -4,7 +4,7 @@
  * Region: BR (Brazil)
  */
 $.extend( $.validator.messages, {
-	required: "Este campo &eacute; requerido.",
+	required: "Este campo &eacute; obrigat&oacute;rio.",
 	remote: "Por favor, corrija este campo.",
 	email: "Por favor, forne&ccedil;a um endere&ccedil;o de email v&aacute;lido.",
 	url: "Por favor, forne&ccedil;a uma URL v&aacute;lida.",
@@ -23,7 +23,7 @@ $.extend( $.validator.messages, {
 	min: $.validator.format( "Por favor, forne&ccedil;a um valor maior ou igual a {0}." ),
 	nifES: "Por favor, forne&ccedil;a um NIF v&aacute;lido.",
 	nieES: "Por favor, forne&ccedil;a um NIE v&aacute;lido.",
-	cifEE: "Por favor, forne&ccedil;a um CIF v&aacute;lido.",
+	cifES: "Por favor, forne&ccedil;a um CIF v&aacute;lido.",
 	postalcodeBR: "Por favor, forne&ccedil;a um CEP v&aacute;lido.",
 	cpfBR: "Por favor, forne&ccedil;a um CPF v&aacute;lido."
 } );


### PR DESCRIPTION
Changed a word to a more commonly used one.
Also, corrected the key 'cifES'. It was misspelled as 'cifEE'.