### PR TITLE
Fixed #1523

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -772,6 +772,7 @@ $.extend( $.validator, {
 				error = this.errorsFor( element ),
 				elementID = this.idOrName( element ),
 				describedBy = $( element ).attr( "aria-describedby" );
+
 			if ( error.length ) {
 				// refresh error/success class
 				error.removeClass( this.settings.validClass ).addClass( this.settings.errorClass );
@@ -803,15 +804,15 @@ $.extend( $.validator, {
 				if ( error.is( "label" ) ) {
 					// If the error is a label, then associate using 'for'
 					error.attr( "for", elementID );
-				} else if ( error.parents( "label[for='" + elementID.replace( /'/g, "\\'" ) + "']" ).length === 0 ) {
+				} else if ( error.parents( "label[for='" + this.escapeCssMeta( elementID ) + "']" ).length === 0 ) {
 					// If the element is not a child of an associated label, then it's necessary
 					// to explicitly apply aria-describedby
 
-					errorID = error.attr( "id" ).replace( /(:|\.|\[|\]|\$)/g, "\\$1" );
+					errorID = error.attr( "id" );
 					// Respect existing non-error aria-describedby
 					if ( !describedBy ) {
 						describedBy = errorID;
-					} else if ( !describedBy.match( new RegExp( "\\b" + errorID + "\\b" ) ) ) {
+					} else if ( !describedBy.match( new RegExp( "\\b" + this.escapeCssMeta( errorID ) + "\\b" ) ) ) {
 						// Add to end of list if not already present
 						describedBy += " " + errorID;
 					}
@@ -822,7 +823,7 @@ $.extend( $.validator, {
 					if ( group ) {
 						$.each( this.groups, function( name, testgroup ) {
 							if ( testgroup === group ) {
-								$( "[name='" + name.replace( /'/g, "\\'" ) + "']", this.currentForm )
+								$( "[name='" + this.escapeCssMeta( name ) + "']", this.currentForm )
 									.attr( "aria-describedby", error.attr( "id" ) );
 							}
 						} );
@@ -841,20 +842,26 @@ $.extend( $.validator, {
 		},
 
 		errorsFor: function( element ) {
-			var name = this.idOrName( element ).replace( /'/g, "\\'" ),
+			var name = this.escapeCssMeta( this.idOrName( element ) ),
 				describer = $( element ).attr( "aria-describedby" ),
 				selector = "label[for='" + name + "'], label[for='" + name + "'] *";
 
 			// aria-describedby should directly reference the error element
 			if ( describer ) {
-				selector = selector + ", #" + describer
-					.replace( /'/g, "\\'" )
+				selector = selector + ", #" + this.escapeCssMeta( describer )
 					.replace( /\s+/g, ", #" );
 			}
 
 			return this
 				.errors()
 				.filter( selector );
+		},
+
+		// See https://api.jquery.com/category/selectors/, for CSS
+		// meta-characters that should be escaped in order to be used with JQuery
+		// as a literal part of a name/id or any selector.
+		escapeCssMeta: function( string ) {
+			return string.replace( /(!|"|#|\$|%|&|'|\(|\)|\*|\+|,|\.|\/|:|;|<|=|>|\?|@|\[|\\|\]|\^|`|\{|\||\}|~)/g, "\\$1");
 		},
 
 		idOrName: function( element ) {
@@ -877,7 +884,7 @@ $.extend( $.validator, {
 		},
 
 		findByName: function( name ) {
-			return $( this.currentForm ).find( "[name='" + name.replace( /'/g, "\\'" ) + "']" );
+			return $( this.currentForm ).find( "[name='" + this.escapeCssMeta( name ) + "']" );
 		},
 
 		getLength: function( value, element ) {

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -291,6 +291,42 @@ test( "test existing non-label used as error element", function(assert) {
 	assert.noErrorFor( field );
 });
 
+test( "test aria-describedby with input names contains special characters (:, ., [, ], $)", function() {
+	var form = $( "#testForm21" ),
+		field = $( "#testForm21\\[\\]\\.value" );
+
+	equal( field.attr( "aria-describedby" ), undefined );
+
+	form.validate( {
+		errorElement: "span",
+		errorPlacement: function() {
+			// Do something
+		}
+	} );
+
+	// Validate the element
+	ok( !field.valid() );
+	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+
+	// Re-run validation
+	field.val( "some" );
+	field.trigger( "keyup" );
+
+	field.val( "something" );
+	field.trigger( "keyup" );
+
+	// `aria-describedby` should remain the same as before.
+	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+
+	// Re-run validation
+	field.val( "something something" );
+	field.trigger( "keyup" );
+
+	ok( field.valid() );
+	// `aria-describedby` should remain the same as before.
+	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+});
+
 test( "test existing non-error aria-describedby", function( assert ) {
 	expect( 8 );
 	var form = $( "#testForm17" ),

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -291,9 +291,9 @@ test( "test existing non-label used as error element", function(assert) {
 	assert.noErrorFor( field );
 });
 
-test( "test aria-describedby with input names contains special characters (:, ., [, ], $)", function() {
+test( "test aria-describedby with input names contains CSS-selector meta-characters", function() {
 	var form = $( "#testForm21" ),
-		field = $( "#testForm21\\[\\]\\.value" );
+		field = $( "#testForm21\\!\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\`\\{\\|\\}\\~" );
 
 	equal( field.attr( "aria-describedby" ), undefined );
 
@@ -306,7 +306,7 @@ test( "test aria-describedby with input names contains special characters (:, .,
 
 	// Validate the element
 	ok( !field.valid() );
-	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+	equal( field.attr( "aria-describedby" ), "testForm21!#$%&'()*+,./:;<=>?@[\\]^`{|}~-error" );
 
 	// Re-run validation
 	field.val( "some" );
@@ -315,16 +315,14 @@ test( "test aria-describedby with input names contains special characters (:, .,
 	field.val( "something" );
 	field.trigger( "keyup" );
 
-	// `aria-describedby` should remain the same as before.
-	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+	equal( field.attr( "aria-describedby" ), "testForm21!#$%&'()*+,./:;<=>?@[\\]^`{|}~-error", "`aria-describedby` should remain the same as before." );
 
 	// Re-run validation
 	field.val( "something something" );
 	field.trigger( "keyup" );
 
 	ok( field.valid() );
-	// `aria-describedby` should remain the same as before.
-	equal( field.attr( "aria-describedby" ), "testForm21[].value-error" );
+	equal( field.attr( "aria-describedby" ), "testForm21!#$%&'()*+,./:;<=>?@[\\]^`{|}~-error", "`aria-describedby` should remain the same as before." );
 });
 
 test( "test existing non-error aria-describedby", function( assert ) {

--- a/test/index.html
+++ b/test/index.html
@@ -376,6 +376,10 @@
 		<input type="checkbox" id="testForm20['checkboxinput']" name="testForm20['checkbox input']" required>
 		<input type="radio" id="testForm20['radioinput']" name="testForm20['radio input']" required>
 	</form>
+	<form id="testForm21">
+		<label for="testForm21[].value">Input text</label>
+		<input type="text" name="testForm21[].value" id="testForm21[].value" required minlength="15">
+	</form>
 </div>
 </body>
 </html>

--- a/test/index.html
+++ b/test/index.html
@@ -377,8 +377,8 @@
 		<input type="radio" id="testForm20['radioinput']" name="testForm20['radio input']" required>
 	</form>
 	<form id="testForm21">
-		<label for="testForm21[].value">Input text</label>
-		<input type="text" name="testForm21[].value" id="testForm21[].value" required minlength="15">
+		<label for="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~">Input text</label>
+		<input type="text" name="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~\" id="testForm21!#$%&'()*+,./:;<=>?@[\]^`{|}~" required minlength="15">
 	</form>
 </div>
 </body>


### PR DESCRIPTION
As suggested by Jörn in [#1523 (comment)](https://github.com/jzaefferer/jquery-validation/issues/1523#issuecomment-122916989):
>Could you look into writing a unit test that captures what you have in your jsfiddle? Once that works, the suggested fix is much easier to verify and the test will prevent further regressions.

This pull request is a continuation of #1587 (so you can close it in favor of this) :
>The error ID was being escaped for use in a regex, but these escaped characters were also being passed on to the aria-describedby value set in the HTML, which means the ID doesn't match up with the ID of the element it's referring to.

**Note:**
The first commit contains the unit test, while the second one contains the fix.