### PR TITLE
Aditional: case-insensitive check for BIC

### DIFF
--- a/src/additional/bic.js
+++ b/src/additional/bic.js
@@ -3,6 +3,8 @@
  *
  * BIC pattern: BBBBCCLLbbb (8 or 11 characters long; bbb is optional)
  *
+ * Validation is case-insensitive. Please make sure to normalize input yourself.
+ *
  * BIC definition in detail:
  * - First 4 characters - bank code (only letters)
  * - Next 2 characters - ISO 3166-1 alpha-2 country code (only letters)
@@ -12,5 +14,5 @@
  * - Last 3 characters - branch code, optional (shall not start with 'X' except in case of 'XXX' for primary office) (letters and digits)
  */
 $.validator.addMethod( "bic", function( value, element ) {
-    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-2])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value );
+    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-2])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value.toUpperCase() );
 }, "Please specify a valid BIC code" );

--- a/src/additional/iban.js
+++ b/src/additional/iban.js
@@ -1,6 +1,8 @@
 /**
  * IBAN is the international bank account number.
  * It has a country - specific format, that is checked here too
+ *
+ * Validation is case-insensitive. Please make sure to normalize input yourself.
  */
 $.validator.addMethod( "iban", function( value, element ) {
 

--- a/test/methods.js
+++ b/test/methods.js
@@ -731,6 +731,20 @@ test( "bic", function() {
 	ok( method( "AAFFFRP1" ), "Valid BIC" );
 	ok( method( "DEUTDEFFAB1" ), "Valid BIC" );
 	ok( method( "DEUTDEFFAXX" ), "Valid BIC" );
+
+	// BIC accept also lowercased values
+	ok( !method( "pbnkdef" ), "Invalid BIC: too short" );
+	ok( !method( "deutdeffa1" ), "Invalid BIC: disallowed length" );
+	ok( !method( "pbnkdeffxxx1" ), "Invalid BIC: too long" );
+	ok( !method( "1bnkdeff" ), "Invalid BIC: invalid digit" );
+	ok( !method( "ingddeffxaa" ), "Invalid BIC: invalid char" );
+
+	ok( method( "deutdeff" ), "Valid BIC (lowercase value)" );
+	ok( method( "deutdeffxxx" ), "Valid BIC (lowercase value)" );
+	ok( method( "pbnkde2f" ), "Valid BIC (lowercase value)" );
+	ok( method( "ingdde91xxx" ), "Valid BIC (lowercase value)" );
+	ok( method( "ingddef2" ), "Valid BIC (lowercase value)" );
+	ok( method( "deutdeffab1" ), "Valid BIC (lowercase value)" );
 } );
 
 test( "postcodeUK", function() {


### PR DESCRIPTION
Squashed and rebased #1547.
The authorship still maintained. So you can close #1547 in favor of this one
