### PR TITLE
Fixes #1632: Error hidden but input error class not removed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -489,9 +489,15 @@ $.extend( $.validator, {
 			this.submitted = {};
 			this.prepareForm();
 			this.hideErrors();
-			var i, elements = this.elements()
+			var elements = this.elements()
 				.removeData( "previousValue" )
 				.removeAttr( "aria-invalid" );
+
+			this.resetElements( elements );
+		},
+
+		resetElements: function( elements ) {
+			var i;
 
 			if ( this.settings.unhighlight ) {
 				for ( i = 0; elements[ i ]; i++ ) {
@@ -1190,6 +1196,7 @@ $.extend( $.validator, {
 				if ( keepRule ) {
 					rules[ prop ] = val.param !== undefined ? val.param : true;
 				} else {
+					$.data( element.form, "validator" ).resetElements( $( element ) );
 					delete rules[ prop ];
 				}
 			}

--- a/test/error-placement.js
+++ b/test/error-placement.js
@@ -407,3 +407,36 @@ test( "test id/name containing single quotes", function() {
 	equal( v.invalidElements()[ 1 ], checkboxElement[ 0 ], "The text element should be invalid" );
 	equal( v.invalidElements()[ 2 ], radioElement[ 0 ], "The text element should be invalid" );
 } );
+
+test( "#1632: Error hidden, but input error class not removed", function() {
+	var v = $( "#testForm23" ).validate( {
+			rules: {
+				box1: {
+					required: {
+						depends: function() {
+							return !!$( "#box2" ).val();
+						}
+					}
+				},
+				box2: {
+					required: {
+						depends: function() {
+							return !!$( "#box1" ).val();
+						}
+					}
+				}
+			}
+		} ),
+		box1 = $( "#box1" ),
+		box2 = $( "#box2" );
+
+	box1.val( "something" );
+	v.form();
+	equal( v.numberOfInvalids(), 1, "There is only one invlid element" );
+	equal( v.invalidElements()[ 0 ], box2[ 0 ], "The box2 element should be invalid" );
+
+	box1.val( "" );
+	v.form();
+	equal( v.numberOfInvalids(), 0, "There is no error" );
+	equal( box2.hasClass( "error" ), false, "Box2 should not have an error class" );
+} );

--- a/test/index.html
+++ b/test/index.html
@@ -398,6 +398,10 @@
 		<div contenteditable id="contenteditableRequiredValid" data-rule-required="true" name="field3">Some text</div>
 		<input id="contenteditableInput" type="text" data-rule-number="true" name="field4" value="ABC" />
 	</form>
+	<form id="testForm23">
+		<input name="box1" id="box1" type="text" value="" />
+		<input name="box2" id="box2" type="text" value="" />
+	</form>
 	<form id="testForm24">
 		<input id="val1" type="hidden" name="val1" value="hello" />
 		<input id="val2" type="text" name="val2" value="" />


### PR DESCRIPTION
When a field has one rule with option `depends` specified and this
dependency mismatch, the plugin will remove it, so that field will not be
validated on submit by the the rule in question. So if that field is
already invalid, only the error message will be hidden and the error class
will remain.

Fixes #1632

(The commit message may need a reword)