### PR TITLE
Core: fixed typo in internal findLastActive method

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -562,7 +562,7 @@ $.extend( $.validator, {
 			var lastActive = this.lastActive;
 			return lastActive && $.grep( this.errorList, function( n ) {
 				return n.element.name === lastActive.name;
-			} ).length === 1 && lastActive;
+			} ).length === 1;
 		},
 
 		elements: function() {


### PR DESCRIPTION
`lastActive` was checked twice within the same expression. fix that.