### PR TITLE
Core: errorList should contain only the errors that it should

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -106,7 +106,9 @@ $.extend( $.fn, {
 			validator = $( this[ 0 ].form ).validate();
 			this.each( function() {
 				valid = validator.element( this ) && valid;
-				errorList = errorList.concat( validator.errorList );
+				if ( !valid ) {
+					errorList = errorList.concat( validator.errorList );
+				}
 			} );
 			validator.errorList = errorList;
 		}
@@ -435,17 +437,18 @@ $.extend( $.validator, {
 				} else {
 					this.invalid[ checkElement.name ] = true;
 				}
+
+				if ( !this.numberOfInvalids() ) {
+
+					// Hide error containers on last error
+					this.toHide = this.toHide.add( this.containers );
+				}
+				this.showErrors();
 			}
 
 			// Add aria-invalid status for screen readers
 			$( element ).attr( "aria-invalid", !result );
 
-			if ( !this.numberOfInvalids() ) {
-
-				// Hide error containers on last error
-				this.toHide = this.toHide.add( this.containers );
-			}
-			this.showErrors();
 			return result;
 		},
 

--- a/test/index.html
+++ b/test/index.html
@@ -394,6 +394,11 @@
 		<div contenteditable id="contenteditableRequiredValid" data-rule-required="true" name="field3">Some text</div>
 		<input id="contenteditableInput" type="text" data-rule-number="true" name="field4" value="ABC" />
 	</form>
+	<form id="testForm24">
+		<input id="val1" type="hidden" name="val1" value="hello" />
+		<input id="val2" type="text" name="val2" value="" />
+		<input id="val3" type="text" name="val3" value="" />
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -1947,3 +1947,26 @@ test( "destroy()", function() {
     validate.destroy();
     strictEqual( $( form ).data( "validator" ), undefined );
 } );
+
+test( "#1618: Errorlist containing more errors than it should", function() {
+	var v = $( "#testForm24" ).validate( {
+			rules: {
+				val1: {
+					required: true
+				},
+				val2: {
+					required: true
+				},
+				val3: {
+					required: true
+				}
+			}
+		} ),
+		inputList = $( "#val1, #val2, #val3" );
+
+	inputList.valid();
+	equal( v.errorList.length, 2, "There is only two errors" );
+
+	inputList.valid();
+	equal( v.errorList.length, 2, "There should be no change in errorList's content" );
+} );


### PR DESCRIPTION
When using the `valid` method on a list of inputs and there is an ignored
input in that list, the errorList is not cleared causing it to slowly
growing larger and larger when calling `valid` several times.

Fixes #1618