### PR TITLE
Core: Extract the file name without including "C:\fakepath\"

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -624,9 +624,9 @@ $.extend( $.validator, {
 		},
 
 		elementValue: function( element ) {
-			var val,
-				$element = $( element ),
-				type = element.type;
+			var $element = $( element ),
+				type = element.type,
+				val, idx;
 
 			if ( type === "radio" || type === "checkbox" ) {
 				return this.findByName( element.name ).filter( ":checked" ).val();
@@ -639,6 +639,31 @@ $.extend( $.validator, {
 			} else {
 				val = $element.val();
 			}
+
+			if ( type === "file" ) {
+
+				// Modern browser (chrome & safari)
+				if ( val.substr( 0, 12 ) === "C:\\fakepath\\" ) {
+					return val.substr( 12 );
+				}
+
+				// Legacy browsers
+				// Unix-based path
+				idx = val.lastIndexOf( "/" );
+				if ( idx >= 0 ) {
+					return val.substr( idx + 1 );
+				}
+
+				// Windows-based path
+				idx = val.lastIndexOf( "\\" );
+				if ( idx >= 0 ) {
+					return val.substr( idx + 1 );
+				}
+
+				// Just the file name
+				return val;
+			}
+
 			if ( typeof val === "string" ) {
 				return val.replace( /\r/g, "" );
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -761,6 +761,55 @@ test( "elementValue() finds radios/checkboxes only within the current form", fun
 	ok( !v.elementValue( foreignRadio ) );
 } );
 
+test( "elementValue() returns the file input's name without the prefix 'C:\\fakepath\\' ", function() {
+	var v = $( "#userForm" ).validate(),
+
+		// A fake file input
+		fileInput = {
+			name: "fakeFile",
+			type: "file",
+			files: {},
+			nodeName: "INPUT",
+			value: "C:\\fakepath\\somefile.txt",
+			form: $( "#userForm" )[ 0 ],
+			hasAttribute: function() { return false; },
+			getAttribute: function( name ) {
+				if ( name === "type" ) {
+					return "file";
+				}
+
+				return undefined;
+			},
+			setAttribute: function() {}
+		};
+
+	v.defaultShowErrors = function() {};
+	v.validationTargetFor = function() {
+		return fileInput;
+	};
+
+	equal( v.elementValue( fileInput ), "somefile.txt" );
+
+	$( fileInput ).rules( "add", {
+		minlength: 10
+	} );
+
+	ok( v.element( fileInput ), "The fake file input is valid (length = 12, minlength = 10)" );
+
+	fileInput.value = "C:\\fakepath\\file.txt";
+	ok( !v.element( fileInput ), "The fake file input is invalid (length = 8, minlength = 10)" );
+
+	$( fileInput ).rules( "remove" );
+	$( fileInput ).rules( "add", {
+		maxlength: 10
+	} );
+
+	ok( v.element( fileInput ), "The fake file input is valid (length = 8, maxlength = 10)" );
+
+	fileInput.value = "C:\\fakepath\\fakefile.txt";
+	ok( !v.element( fileInput ), "The fake file input is invalid (length = 12, maxlength = 10)" );
+} );
+
 test( "validating multiple checkboxes with 'required'", function() {
 	expect( 3 );
 	var checkboxes = $( "#form input[name=check3]" ).prop( "checked", false ),


### PR DESCRIPTION
For historical reasons, the value IDL attribute prefixes the file name
with the string "C:\fakepath\". As a result of this, this fix will extract
the file name from the value IDL attribute in a backwards-compatible way.

For more details, see:
 - http://www.w3.org/TR/html5/forms.html#dom-input-value-filename
 - http://www.w3.org/TR/html5/forms.html#fakepath-srsly

Fixes #1615