### PR TITLE
BIC: allow digits 1-9 in second place of location

### DIFF
--- a/src/additional/bic.js
+++ b/src/additional/bic.js
@@ -10,9 +10,9 @@
  * - Next 2 characters - ISO 3166-1 alpha-2 country code (only letters)
  * - Next 2 characters - location code (letters and digits)
  *   a. shall not start with '0' or '1'
- *   b. second character must be a letter ('O' is not allowed) or one of the following digits ('0' for test (therefore not allowed), '1' for passive participant and '2' for active participant)
+ *   b. second character must be a letter ('O' is not allowed) or digit ('0' for test (therefore not allowed), '1' denoting passive participant, '2' typically reverse-billing)
  * - Last 3 characters - branch code, optional (shall not start with 'X' except in case of 'XXX' for primary office) (letters and digits)
  */
 $.validator.addMethod( "bic", function( value, element ) {
-    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-2])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value.toUpperCase() );
+    return this.optional( element ) || /^([A-Z]{6}[A-Z2-9][A-NP-Z1-9])(X{3}|[A-WY-Z0-9][A-Z0-9]{2})?$/.test( value.toUpperCase() );
 }, "Please specify a valid BIC code" );

--- a/test/methods.js
+++ b/test/methods.js
@@ -760,7 +760,6 @@ test( "bic", function() {
 	ok( !method( "PBNKDEFFXXX1" ), "Invalid BIC: too long" );
 	ok( !method( "1BNKDEFF" ), "Invalid BIC: invalid digit" );
 	ok( !method( "PBNKDE1F" ), "Invalid BIC: invalid digit" );
-	ok( !method( "PBNKDEF0" ), "Invalid BIC: invalid digit" );
 	ok( !method( "PBNKDEFO" ), "Invalid BIC: invalid char" );
 	ok( !method( "INGDDEFFXAA" ), "Invalid BIC: invalid char" );
 	ok( !method( "DEUTDEF0" ), "Invalid BIC: invalid digit" );

--- a/test/methods.js
+++ b/test/methods.js
@@ -760,7 +760,7 @@ test( "bic", function() {
 	ok( !method( "PBNKDEFFXXX1" ), "Invalid BIC: too long" );
 	ok( !method( "1BNKDEFF" ), "Invalid BIC: invalid digit" );
 	ok( !method( "PBNKDE1F" ), "Invalid BIC: invalid digit" );
-	ok( !method( "PBNKDEF3" ), "Invalid BIC: invalid digit" );
+	ok( !method( "PBNKDEF0" ), "Invalid BIC: invalid digit" );
 	ok( !method( "PBNKDEFO" ), "Invalid BIC: invalid char" );
 	ok( !method( "INGDDEFFXAA" ), "Invalid BIC: invalid char" );
 	ok( !method( "DEUTDEF0" ), "Invalid BIC: invalid digit" );
@@ -775,6 +775,7 @@ test( "bic", function() {
 	ok( method( "AAFFFRP1" ), "Valid BIC" );
 	ok( method( "DEUTDEFFAB1" ), "Valid BIC" );
 	ok( method( "DEUTDEFFAXX" ), "Valid BIC" );
+	ok( method( "SSKNDE77XXX" ), "Valid BIC" );
 
 	// BIC accept also lowercased values
 	ok( !method( "pbnkdef" ), "Invalid BIC: too short" );


### PR DESCRIPTION
It seems that the BIC specification (https://en.wikipedia.org/wiki/ISO_9362 ) was interpreted too strictly, only allowing digits 1 and 2 while those 2 just have a special meaning, but all 1-9 are allowed.

Example: SSKNDE77XXX - http://bank-code.net/swift-code/SSKNDE77XXX.html (Sparkasse Nuernberg)