### PR TITLE
Persian localization fix

### DIFF
--- a/src/localization/messages_fa.js
+++ b/src/localization/messages_fa.js
@@ -19,8 +19,8 @@ $.extend( $.validator.messages, {
 	minlength: $.validator.format( "لطفا کمتر از {0} حرف وارد نکنید." ),
 	rangelength: $.validator.format( "لطفا مقداری بین {0} تا {1} حرف وارد کنید." ),
 	range: $.validator.format( "لطفا مقداری بین {0} تا {1} حرف وارد کنید." ),
-	max: $.validator.format( "لطفا مقداری کمتر از {0} حرف وارد کنید." ),
-	min: $.validator.format( "لطفا مقداری بیشتر از {0} حرف وارد کنید." ),
+	max: $.validator.format( "لطفا مقداری کمتر از {0} وارد کنید." ),
+	min: $.validator.format( "لطفا مقداری بیشتر از {0} وارد کنید." ),
 	minWords: $.validator.format( "لطفا حداقل {0} کلمه وارد کنید." ),
 	maxWords: $.validator.format( "لطفا حداکثر {0} کلمه وارد کنید." )
 } );


### PR DESCRIPTION
Hello, and thank you for this good plugin
I find a bug in Farsi (Persian) localization exist in messages_fa.js
The "min"&"max" methods messages in that file have bug. The Farsi "min"
`s message has this meaning: “please enter value greater that {0}
words.”
Phrase meaning "word" should be removed from Farsi message.