### PR TITLE
Core: Bind the `blur` event just once in `equalTo` rule

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1061,7 +1061,10 @@ $.extend( $.validator, {
 
 			$( this.currentForm )
 				.off( ".validate" )
-				.removeData( "validator" );
+				.removeData( "validator" )
+				.find( ".validate-equalTo-blur" )
+					.off( ".validate-equalTo" )
+					.removeClass( "validate-equalTo-blur" );
 		}
 
 	},
@@ -1386,10 +1389,9 @@ $.extend( $.validator, {
 		equalTo: function( value, element, param ) {
 
 			// Bind to the blur event of the target in order to revalidate whenever the target field is updated
-			// TODO find a way to bind the event just once, avoiding the unbind-rebind overhead
 			var target = $( param );
-			if ( this.settings.onfocusout ) {
-				target.off( ".validate-equalTo" ).on( "blur.validate-equalTo", function() {
+			if ( this.settings.onfocusout && target.not( ".validate-equalTo-blur" ).length ) {
+				target.addClass( "validate-equalTo-blur" ).on( "blur.validate-equalTo", function() {
 					$( element ).valid();
 				} );
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -2150,15 +2150,21 @@ test( "Validation triggered on radio and checkbox via click", function() {
 } );
 
 test( "destroy()", function() {
-    expect( 2 );
+	expect( 6 );
 
-    var form = $( "#form" ),
-        validate = form.validate();
+	var form = $( "#testForm5" ),
+		validate = form.validate();
 
-    strictEqual( $( form ).data( "validator" ), validate );
+	strictEqual( form.data( "validator" ), validate );
 
-    validate.destroy();
-    strictEqual( $( form ).data( "validator" ), undefined );
+	form.valid();
+	equal( $( "#x1", form ).hasClass( "validate-equalTo-blur" ), true, "The blur event should be bound to this element" );
+	equal( $( "#x2", form ).hasClass( "validate-equalTo-blur" ), true, "The blur event should be bound to this element" );
+
+	validate.destroy();
+	strictEqual( form.data( "validator" ), undefined );
+	equal( $( "#x1", form ).hasClass( "validate-equalTo-blur" ), false, "The blur event should be unbound from this element" );
+	equal( $( "#x2", form ).hasClass( "validate-equalTo-blur" ), false, "The blur event should be unbound from this element" );
 } );
 
 test( "#1618: Errorlist containing more errors than it should", function() {


### PR DESCRIPTION
bind the event just once, avoiding the unbind-rebind overhead.
Also, unbind it when destroying the plugin.

Ref #1704
Ref #1707