### PR TITLE
Tests: Calling .rules() on an empty jQuery object results in an error.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -117,6 +117,12 @@ $.extend( $.fn, {
 
 	// http://jqueryvalidation.org/rules/
 	rules: function( command, argument ) {
+
+		// If nothing is selected, return nothing; can't chain anyway
+		if ( !this.length ) {
+			return;
+		}
+
 		var element = this[ 0 ],
 			settings, staticRules, existingRules, data, param, filtered;
 

--- a/test/rules.js
+++ b/test/rules.js
@@ -396,3 +396,10 @@ test( "rules(), normalizer", function() {
 		return err.name === "TypeError" && err.message === "The normalizer should return a string value.";
 	}, "This should throw a TypeError exception." );
 } );
+
+test( "rules() - on empty jquery set #1706", function() {
+	var element = $( "#firstname .mynonexistantclass" );
+
+	var result = element.rules( "add", "whatever" );
+	strictEqual( result, undefined, "can work on an empty set without a js error" );
+} );


### PR DESCRIPTION
Refs #1706