### PR TITLE
min rule

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1369,6 +1369,8 @@ $.extend( $.validator, {
 
 		// http://jqueryvalidation.org/min-method/
 		min: function( value, element, param ) {
+			if (this.settings.rules[element.name].number)
+				value = value.replace(/,/g, '');
 			return this.optional( element ) || value >= param;
 		},
 


### PR DESCRIPTION
If the filed is allowed to be number then it accepts comma in value (i.e. 1200 and 1,200 both are valid). Now if "min" rule is provided with number then currently even if i'm entering 1,200 error(Please enter a value greater than or equal to 0.) is throwing. So if the current element has number and min both rules then we need to replace comma with 0 length string.