### PR TITLE
Update step validation method to handle floating points correctly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1385,17 +1385,39 @@ $.extend( $.validator, {
 		// http://jqueryvalidation.org/step-method/
 		step: function( value, element, param ) {
 			var type = $( element ).attr( "type" ),
-				errorMessage = "Step attribute on input type " + type + " is not supported.",
-				supportedTypes = [ "text", "number", "range" ],
-				re = new RegExp( "\\b" + type + "\\b" ),
-				notSupported = type && !re.test( supportedTypes.join() );
+            errorMessage = "Step attribute on input type " + type + " is not supported.",
+            supportedTypes = [ "text", "number", "range" ],
+            re = new RegExp( "\\b" + type + "\\b" ),
+            notSupported = type && !re.test( supportedTypes.join() ),
+            decimalPlaces = function( num ) {
+              var match = ( "" + num ).match( /(?:\.(\d+))?$/ );
+              if ( !match ) {
+                return 0;
+              }
 
-			// Works only for text, number and range input types
-			// TODO find a way to support input types date, datetime, datetime-local, month, time and week
-			if ( notSupported ) {
-				throw new Error( errorMessage );
-			}
-			return this.optional( element ) || ( (value / param) % 1 === 0 );
+              // Number of digits right of decimal point.
+              return match[ 1 ] ? match[ 1 ].length : 0;
+            },
+            toInt = function( num ) {
+              return Math.round( num * Math.pow( 10, decimals ) );
+            },
+            valid = true,
+            decimals;
+
+          // Works only for text, number and range input types
+          // TODO find a way to support input types date, datetime, datetime-local, month, time and week
+          if ( notSupported ) {
+            throw new Error( errorMessage );
+          }
+
+          decimals = decimalPlaces( param );
+
+          // Value can't have too many decimals
+          if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
+            valid = false;
+          }
+
+          return this.optional( element ) || valid;
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/

--- a/src/core.js
+++ b/src/core.js
@@ -1395,7 +1395,7 @@ $.extend( $.validator, {
 			if ( notSupported ) {
 				throw new Error( errorMessage );
 			}
-			return this.optional( element ) || ( value % param === 0 );
+			return this.optional( element ) || ( (value / param) % 1 === 0 );
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/


### PR DESCRIPTION
When validating a number input with step = 0.01 (or any floating point number).
The current step method always says the input is invalid.
This is down to the way Javascript handles floating point numbers and rounding errors when using the modulus function.

e.g.  in javascript 15 % 0.01 = 0.009999999999999688 even though mathematically it should be 0

I suggest doing (value / param) % 1 instead since the division is handled correctly and the modulus is there to determine only if the division returns a whole number.

This then gives the expected outcome for any step

e.g. (15 / 0.01)% 1 = 1500 % 1 = 0             => valid
(15.555 / 0.01)% 1 = 1555.5 % 1 = 0.5       => invalid