### PR TITLE
Core: Adjust `delegate` to work with `contenteditable` elements

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -381,6 +381,10 @@ $.extend( $.validator, {
 			} );
 
 			function delegate( event ) {
+				if ( this.hasAttribute( "contenteditable" ) ) {
+					this.form = $( this ).closest( "form" )[ 0 ];
+				}
+
 				var validator = $.data( this.form, "validator" ),
 					eventType = "on" + event.type.replace( /^validate/, "" ),
 					settings = validator.settings;

--- a/test/test.js
+++ b/test/test.js
@@ -1087,6 +1087,12 @@ test( "works on contenteditable fields", function( assert ) {
 	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
 	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
 	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );
+
+	var el = $( "#contenteditableRequiredValid" );
+	el.text( "" );
+	el.trigger( "focusout" );
+	el.trigger( "keyup" );
+	assert.hasError( el, "This field is required." );
 } );
 
 module( "misc" );


### PR DESCRIPTION
I can add more tests if they are needed.