### PR TITLE
Core: Fixed issue with contenteditable elements in forms where events would cause exceptions

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -381,6 +381,10 @@ $.extend( $.validator, {
 			} );
 
 			function delegate( event ) {
+				if (!this.form && this.hasAttribute("contenteditable")) {
+			        this.form = $(this).closest("form")[0];
+			    }
+			    
 				var validator = $.data( this.form, "validator" ),
 					eventType = "on" + event.type.replace( /^validate/, "" ),
 					settings = validator.settings;

--- a/src/core.js
+++ b/src/core.js
@@ -383,7 +383,7 @@ $.extend( $.validator, {
 			function delegate( event ) {
 
 				// Set form expando on contenteditable
-				if ( this.hasAttribute( "contenteditable" ) ) {
+				if ( !this.form && this.hasAttribute( "contenteditable" ) ) {
 					this.form = $( this ).closest( "form" )[ 0 ];
 				}
 

--- a/src/core.js
+++ b/src/core.js
@@ -381,9 +381,10 @@ $.extend( $.validator, {
 			} );
 
 			function delegate( event ) {
-				if (!this.form && this.hasAttribute("contenteditable")) {
-			        this.form = $(this).closest("form")[0];
-			    }
+				// Set form expando on contenteditable
+				if ( this.hasAttribute( "contenteditable" ) ) {
+					this.form = $( this ).closest( "form" )[ 0 ];
+				}
 			    
 				var validator = $.data( this.form, "validator" ),
 					eventType = "on" + event.type.replace( /^validate/, "" ),

--- a/src/core.js
+++ b/src/core.js
@@ -381,11 +381,12 @@ $.extend( $.validator, {
 			} );
 
 			function delegate( event ) {
+
 				// Set form expando on contenteditable
 				if ( this.hasAttribute( "contenteditable" ) ) {
 					this.form = $( this ).closest( "form" )[ 0 ];
 				}
-			    
+
 				var validator = $.data( this.form, "validator" ),
 					eventType = "on" + event.type.replace( /^validate/, "" ),
 					settings = validator.settings;

--- a/test/test.js
+++ b/test/test.js
@@ -1093,8 +1093,6 @@ test( "works on contenteditable fields on input event", function( assert ) {
 	$( "#contenteditableForm" ).validate();
 
 	$( "#contenteditableNumberInvalid" ).focus();
-	$( "#contenteditableRequiredInvalid" ).focus();
-	$( "#contenteditableInput" ).keyup();
 	$( "#contenteditableNumberValid" ).keyup();
 	$( "#contenteditableRequiredValid" ).keyup();
 

--- a/test/test.js
+++ b/test/test.js
@@ -1093,7 +1093,9 @@ test( "works on contenteditable fields on input event", function( assert ) {
 	$( "#contenteditableForm" ).validate();
 
 	$( "#contenteditableNumberInvalid" ).focus();
-	$( "#contenteditableNumberValid" ).keyup();
+	$( "#contenteditableRequiredInvalid" ).focus();
+	$( "#contenteditableInput" ).keyup();
+	$( "#contenteditableNumberValid" ).focus();
 	$( "#contenteditableRequiredValid" ).keyup();
 
 	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );

--- a/test/test.js
+++ b/test/test.js
@@ -1090,16 +1090,15 @@ test( "works on contenteditable fields", function( assert ) {
 } );
 
 test( "works on contenteditable fields on input event", function( assert ) {
-	var form = $( "#contenteditableForm" );
+	$( "#contenteditableForm" ).validate();
+
 	$( "#contenteditableNumberInvalid" ).focus();
 	$( "#contenteditableRequiredInvalid" ).focus();
 	$( "#contenteditableInput" ).keyup();
 	$( "#contenteditableNumberValid" ).keyup();
 	$( "#contenteditableRequiredValid" ).keyup();
-	
+
 	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );
-	assert.hasError( $( "#contenteditableRequiredInvalid" ), "This field is required." );
-	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
 	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
 	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );
 } );

--- a/test/test.js
+++ b/test/test.js
@@ -1089,6 +1089,21 @@ test( "works on contenteditable fields", function( assert ) {
 	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );
 } );
 
+test( "works on contenteditable fields on input event", function( assert ) {
+	var form = $( "#contenteditableForm" );
+	$( "#contenteditableNumberInvalid" ).focus();
+	$( "#contenteditableRequiredInvalid" ).focus();
+	$( "#contenteditableInput" ).keyup();
+	$( "#contenteditableNumberValid" ).keyup();
+	$( "#contenteditableRequiredValid" ).keyup();
+	
+	assert.hasError( $( "#contenteditableNumberInvalid" ), "Please enter a valid number." );
+	assert.hasError( $( "#contenteditableRequiredInvalid" ), "This field is required." );
+	assert.hasError( $( "#contenteditableInput" ), "Please enter a valid number." );
+	assert.noErrorFor( $( "#contenteditableNumberValid" ) );
+	assert.noErrorFor( $( "#contenteditableRequiredValid" ) );
+} );
+
 module( "misc" );
 
 test( "success option", function() {


### PR DESCRIPTION
Where content editable fields are in a <form> exception will happen. 
This is because form validation process hasn't been triggered, but events on the inputs will trigger their validation.

The proposed fix addresses this issue by checking if the elements have been the <form> reference, if they don't and are contenteditable element it will be created at that time.

The solution is the same as in $.validator.elements(), but covers another flow for validating a single input field.