### PR TITLE
Correct notEqualTo jQuery reference.

### DIFF
--- a/src/additional/notEqualTo.js
+++ b/src/additional/notEqualTo.js
@@ -1,3 +1,3 @@
-jQuery.validator.addMethod( "notEqualTo", function( value, element, param ) {
+$.validator.addMethod( "notEqualTo", function( value, element, param ) {
 	return this.optional( element ) || !$.validator.methods.equalTo.call( this, value, element, param );
 }, "Please enter a different value, values must not be the same." );


### PR DESCRIPTION
Additional method was referencing the global jQuery object instead of the injected $.

Fixes 1773. 