### PR TITLE
Update step validation to handle floating points correctly

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1385,17 +1385,39 @@ $.extend( $.validator, {
 		// http://jqueryvalidation.org/step-method/
 		step: function( value, element, param ) {
 			var type = $( element ).attr( "type" ),
-				errorMessage = "Step attribute on input type " + type + " is not supported.",
-				supportedTypes = [ "text", "number", "range" ],
-				re = new RegExp( "\\b" + type + "\\b" ),
-				notSupported = type && !re.test( supportedTypes.join() );
+            errorMessage = "Step attribute on input type " + type + " is not supported.",
+            supportedTypes = [ "text", "number", "range" ],
+            re = new RegExp( "\\b" + type + "\\b" ),
+            notSupported = type && !re.test( supportedTypes.join() ),
+            decimalPlaces = function( num ) {
+              var match = ( "" + num ).match( /(?:\.(\d+))?$/ );
+              if ( !match ) {
+                return 0;
+              }
 
-			// Works only for text, number and range input types
-			// TODO find a way to support input types date, datetime, datetime-local, month, time and week
-			if ( notSupported ) {
-				throw new Error( errorMessage );
-			}
-			return this.optional( element ) || ( (value / param) % 1 === 0 );
+              // Number of digits right of decimal point.
+              return match[ 1 ] ? match[ 1 ].length : 0;
+            },
+            toInt = function( num ) {
+              return Math.round( num * Math.pow( 10, decimals ) );
+            },
+            valid = true,
+            decimals;
+
+          // Works only for text, number and range input types
+          // TODO find a way to support input types date, datetime, datetime-local, month, time and week
+          if ( notSupported ) {
+            throw new Error( errorMessage );
+          }
+
+          decimals = decimalPlaces( param );
+
+          // Value can't have too many decimals
+          if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
+            valid = false;
+          }
+
+          return this.optional( element ) || valid;
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/

--- a/src/core.js
+++ b/src/core.js
@@ -1385,39 +1385,39 @@ $.extend( $.validator, {
 		// http://jqueryvalidation.org/step-method/
 		step: function( value, element, param ) {
 			var type = $( element ).attr( "type" ),
-            errorMessage = "Step attribute on input type " + type + " is not supported.",
-            supportedTypes = [ "text", "number", "range" ],
-            re = new RegExp( "\\b" + type + "\\b" ),
-            notSupported = type && !re.test( supportedTypes.join() ),
-            decimalPlaces = function( num ) {
-              var match = ( "" + num ).match( /(?:\.(\d+))?$/ );
-              if ( !match ) {
-                return 0;
-              }
+				errorMessage = "Step attribute on input type " + type + " is not supported.",
+				supportedTypes = [ "text", "number", "range" ],
+				re = new RegExp( "\\b" + type + "\\b" ),
+				notSupported = type && !re.test( supportedTypes.join() ),
+				decimalPlaces = function( num ) {
+					var match = ( "" + num ).match( /(?:\.(\d+))?$/ );
+					if ( !match ) {
+						return 0;
+					}
 
-              // Number of digits right of decimal point.
-              return match[ 1 ] ? match[ 1 ].length : 0;
-            },
-            toInt = function( num ) {
-              return Math.round( num * Math.pow( 10, decimals ) );
-            },
-            valid = true,
-            decimals;
+					// Number of digits right of decimal point.
+					return match[ 1 ] ? match[ 1 ].length : 0;
+				},
+				toInt = function( num ) {
+					return Math.round( num * Math.pow( 10, decimals ) );
+				},
+				valid = true,
+				decimals;
 
-          // Works only for text, number and range input types
-          // TODO find a way to support input types date, datetime, datetime-local, month, time and week
-          if ( notSupported ) {
-            throw new Error( errorMessage );
-          }
+			// Works only for text, number and range input types
+			// TODO find a way to support input types date, datetime, datetime-local, month, time and week
+			if ( notSupported ) {
+				throw new Error( errorMessage );
+			}
 
-          decimals = decimalPlaces( param );
+			decimals = decimalPlaces( param );
 
-          // Value can't have too many decimals
-          if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
-            valid = false;
-          }
+			// Value can't have too many decimals
+			if ( decimalPlaces( value ) > decimals || toInt( value ) % toInt( param ) !== 0 ) {
+				valid = false;
+			}
 
-          return this.optional( element ) || valid;
+			return this.optional( element ) || valid;
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/

--- a/src/core.js
+++ b/src/core.js
@@ -1395,7 +1395,7 @@ $.extend( $.validator, {
 			if ( notSupported ) {
 				throw new Error( errorMessage );
 			}
-			return this.optional( element ) || ( value % param === 0 );
+			return this.optional( element ) || ( (value / param) % 1 === 0 );
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/

--- a/test/index.html
+++ b/test/index.html
@@ -211,6 +211,7 @@
 		<input type="text" name="action" value="0" id="value1">
 		<input type="text" name="text2" value="10" id="value2">
 		<input type="text" name="text2" value="1000" id="value3">
+		<input type="text" name="text2" value="0.00125" id="value4">
 		<input type="radio" name="radio1" id="radio1">
 		<input type="radio" name="radio1" id="radio1a">
 		<input type="radio" name="radio2" id="radio2" checked="checked">

--- a/test/methods.js
+++ b/test/methods.js
@@ -360,11 +360,23 @@ test( "step", function() {
 	var v = jQuery( "#form" ).validate(),
 		method = $.validator.methods.step,
 		param = 1000,
-		e = $( "#value1, #value2, #value3" );
+		e = $( "#value1, #value2, #value3, #value4" );
 
 	ok( method.call( v, e[ 0 ].value, e[ 0 ], param ), "Valid text input" );
 	ok( !method.call( v, e[ 1 ].value, e[ 1 ], param ), "Invalid text input" );
 	ok( method.call( v, e[ 2 ].value, e[ 2 ], param ), "Valid text input" );
+} );
+
+test( "#1760 - step modulo/remainder regression tests", function() {
+	var v = jQuery( "#form" ).validate(),
+		method = $.validator.methods.step,
+		param = 0.00125,
+		e = $( "#value4" );
+
+	for ( var i = 1; i <= 1000; i++ ) {
+		e[ 0 ].value = ( param * 100000 * i ) / 100000;
+		ok( method.call( v, e[ 0 ].value, e[ 0 ], param ), "Ensure " + e[ 0 ].value + " % " + param + " === 0 is valid" );
+	}
 } );
 
 test( "equalTo", function() {


### PR DESCRIPTION
This is a new PR based on #1760. I couldn't find a way to modify that actual PR with my additional changes so I created a new PR that includes unit tests. @adhayward @staabm 

Tests: Added regression unit tests for PR #1760
Testing small fraction steps to ensure correct modulo operation.
Cleaned up @adhayward's formatting, was using spaces instead of tabs.
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Remainder_()
See: http://wiki.ecmascript.org/doku.php?id=strawman:modulo_operator
See: http://stackoverflow.com/questions/3966484/floating-point-numbers-and-javascript-modulus-operator