### PR TITLE
Core: Fix when adding a step of 0.01 that only bits are allowed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1400,7 +1400,7 @@ $.extend( $.validator, {
 			if ( notSupported ) {
 				throw new Error( errorMessage );
 			}
-			return this.optional( element ) || ( value % param === 0 );
+			return this.optional( element ) || ( ( value / param ) % 1 === 0 );
 		},
 
 		// http://jqueryvalidation.org/equalTo-method/


### PR DESCRIPTION
When using a step of 0.01 the validation starts to do funky.

When you have a step of 0.01 the following are allowed:
0, 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, etc...