### PR TITLE
Changes jQuery alias 'expr[":"]' to 'expr.pseudos'

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -186,7 +186,7 @@ $.extend( $.fn, {
 } );
 
 // Custom selectors
-$.extend( $.expr[ ":" ], {
+$.extend( $.expr.pseudos, {
 
 	// http://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {

--- a/src/core.js
+++ b/src/core.js
@@ -186,7 +186,7 @@ $.extend( $.fn, {
 } );
 
 // Custom selectors
-$.extend( $.expr.pseudos || $.expr[ ":" ], {
+$.extend( $.expr.pseudos || $.expr[ ":" ], {		// '|| $.expr[ ":" ]' here enables backwards compatibility to jQuery 1.7. Can be removed when dropping jQ 1.7.x support
 
 	// http://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {

--- a/src/core.js
+++ b/src/core.js
@@ -186,7 +186,7 @@ $.extend( $.fn, {
 } );
 
 // Custom selectors
-$.extend( $.expr.pseudos, {
+$.extend( $.expr.pseudos || $.expr[ ":" ], {
 
 	// http://jqueryvalidation.org/blank-selector/
 	blank: function( a ) {


### PR DESCRIPTION
Uses newer alias as per jQuery Migrate documentation
https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigra
te-jqueryexpr-is-jqueryexprpseudos
I want to resolve #1813 