### PR TITLE
Move jquery dependencies to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,6 @@
 		"dist/jquery.validate.js"
 	],
 	"main": "dist/jquery.validate.js",
-	"dependencies": {
-		"jquery": "^1.7 || ^2.0"
-	},
 	"devDependencies": {
 		"commitplease": "2.3.1",
 		"grunt": "1.0.1",
@@ -48,7 +45,8 @@
 		"grunt-contrib-watch": "1.0.0",
 		"grunt-jscs": "2.8.0",
 		"grunt-text-replace": "0.4.0",
-		"qunitjs": "2.0.0"
+		"qunitjs": "2.0.0",
+		"jquery": "^1.7 || ^2.0"
 	},
 	"keywords": [
 		"jquery",


### PR DESCRIPTION
I installed jquery-validation from `npm`. After compiled with `webpack` I have two version jquery on my bundle, first - mine, second - it is the plugin jquery dependencies. And so I moved  this dependencies to dev dependencies.

Weird, why this package have own `node_modules` on folder after installed with `npm`
