### PR TITLE
Init: add binding for input with button type

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -399,7 +399,7 @@ $.extend( $.validator, {
 					":text, [type='password'], [type='file'], select, textarea, [type='number'], [type='search'], " +
 					"[type='tel'], [type='url'], [type='email'], [type='datetime'], [type='date'], [type='month'], " +
 					"[type='week'], [type='time'], [type='datetime-local'], [type='range'], [type='color'], " +
-					"[type='radio'], [type='checkbox'], [contenteditable]", delegate )
+					"[type='radio'], [type='checkbox'], [contenteditable], [type='button']", delegate )
 
 				// Support: Chrome, oldIE
 				// "select" is provided as event.target when clicking a option

--- a/test/index.html
+++ b/test/index.html
@@ -228,6 +228,7 @@
 		<input type="hidden" name="hidden" id="hidden1">
 		<input type="text" style="display:none;" name="foo[bar]" id="hidden2">
 		<input type="text" readonly="readonly" id="name" name="name" value="name">
+		<input type="button" name="button" value="Click me">
 		<button name="button">Button</button>
 		<textarea id="area1" name="area1">foobar</textarea>
 		<textarea id="area2" name="area2"></textarea>
@@ -432,7 +433,7 @@
 			<option value="2015">2015</option>
 			<option value="2016">2016</option>
 		</select>
-	</form>	
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -438,6 +438,42 @@ QUnit.test( "validation triggered on radio/checkbox when using keyboard", functi
 	} );
 } );
 
+QUnit.test( "validation triggered on button", function( assert ) {
+	assert.expect( 1 );
+	var input, i, events, triggeredEvents = 0,
+		done = assert.async();
+
+	$( "#form" ).validate( {
+		onfocusin: function() {
+			triggeredEvents++;
+		},
+		onfocusout: function() {
+			triggeredEvents++;
+		},
+		onkeyup: function() {
+			triggeredEvents++;
+		}
+	} );
+
+	events = [
+		$.Event( "focusin" ),
+		$.Event( "focusout" ),
+		$.Event( "keyup" )
+	];
+
+	input = $( "#form :button" );
+	for ( i = 0; i < events.length; i++ ) {
+		input.trigger( events[ i ] );
+	}
+
+	setTimeout( function() {
+
+		// Assert all event handlers fired
+		assert.equal( triggeredEvents, 6 );
+		done();
+	} );
+} );
+
 QUnit.test( "validation triggered on radio/checkbox when using mouseclick", function( assert ) {
     assert.expect( 1 );
 	var input, i, events, triggeredEvents = 0,


### PR DESCRIPTION
Resolves #1891 

I'm adding the easiest solution from list described in issue.
Here example with build based on my changes - https://jsfiddle.net/5vumyq0k/


