### PR TITLE
Added support for button elements with descendants

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -31,6 +31,7 @@ $.extend( $.fn, {
 					if ( $element.is( "button, input" ) ) {
 						return $element;
 					}
+
 					// In case the submit button has descendants, the target might be a descendant.
 					// Return the actual button instead, or undefined if none is found.
 					var buttonRoots = $element.parents( "button" );

--- a/src/core.js
+++ b/src/core.js
@@ -29,7 +29,7 @@ $.extend( $.fn, {
 				function getSubmitButton( element ) {
 					var $element = $( element );
 					if ( $element.is( "button, input" ) ) {
-						return $element;
+						return element;
 					}
 
 					// In case the submit button has descendants, the target might be a descendant.

--- a/src/core.js
+++ b/src/core.js
@@ -26,22 +26,8 @@ $.extend( $.fn, {
 		if ( validator.settings.onsubmit ) {
 
 			this.on( "click.validate", ":submit", function( event ) {
-				function getSubmitButton( element ) {
-					var $element = $( element );
-					if ( $element.is( "button, input" ) ) {
-						return element;
-					}
-
-					// In case the submit button has descendants, the target might be a descendant.
-					// Return the actual button instead, or undefined if none is found.
-					var buttonRoots = $element.parents( "button" );
-					if ( buttonRoots.length ) {
-						return buttonRoots[ 0 ];
-					}
-				}
-
 				if ( validator.settings.submitHandler ) {
-					validator.submitButton = getSubmitButton( event.target );
+					validator.submitButton = event.currentTarget;
 				}
 
 				// Allow suppressing validation by adding a cancel class to the submit button

--- a/src/core.js
+++ b/src/core.js
@@ -26,8 +26,21 @@ $.extend( $.fn, {
 		if ( validator.settings.onsubmit ) {
 
 			this.on( "click.validate", ":submit", function( event ) {
+				function getSubmitButton( element ) {
+					var $element = $( element );
+					if ( $element.is( "button, input" ) ) {
+						return $element;
+					}
+					// In case the submit button has descendants, the target might be a descendant.
+					// Return the actual button instead, or undefined if none is found.
+					var buttonRoots = $element.parents( "button" );
+					if ( buttonRoots.length ) {
+						return buttonRoots[ 0 ];
+					}
+				}
+
 				if ( validator.settings.submitHandler ) {
-					validator.submitButton = event.target;
+					validator.submitButton = getSubmitButton( event.target );
 				}
 
 				// Allow suppressing validation by adding a cancel class to the submit button

--- a/test/index.html
+++ b/test/index.html
@@ -435,6 +435,10 @@
 			<option value="2016">2016</option>
 		</select>
 	</form>
+	<form id="testForm27">
+		<input name="year"/>
+		<button name="submitForm27" value="someValue" type="submit"><span>Submit</span></button>
+	</form>
 </div>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -397,6 +397,28 @@ QUnit.test( "submitHandler keeps submitting button", function( assert ) {
 	$( "#userForm" ).submit();
 } );
 
+QUnit.test( "submitHandler keeps submitting button, even if descendants are clicked", function( assert ) {
+	var button, event, buttonDescendant;
+
+	$( "#testForm27" ).validate( {
+		debug: true,
+		submitHandler: function( form ) {
+
+			// Dunno how to test this better; this tests the implementation that uses a hidden input
+			var hidden = $( form ).find( "input:hidden" )[ 0 ];
+			assert.deepEqual( hidden.value, button.value );
+			assert.deepEqual( hidden.name, button.name );
+		}
+	} );
+	$( "#testForm27 [name=\"year\"]" ).val( "2016" );
+	button = $( "#testForm27 :submit" )[ 0 ];
+	buttonDescendant = $(button).find("span");
+	event = $.Event( "click" );
+	event.preventDefault();
+	$.event.trigger( event, null, buttonDescendant );
+	$( "#testForm27" ).submit();
+} );
+
 QUnit.test( "validation triggered on radio/checkbox when using keyboard", function( assert ) {
     assert.expect( 1 );
 	var input, i, events, triggeredEvents = 0,

--- a/test/test.js
+++ b/test/test.js
@@ -412,7 +412,7 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 	} );
 	$( "#testForm27 [name=\"year\"]" ).val( "2016" );
 	button = $( "#testForm27 :submit" )[ 0 ];
-	buttonDescendant = $(button).find( "span" );
+	buttonDescendant = $( button ).find( "span" );
 	event = $.Event( "click" );
 	event.preventDefault();
 	$.event.trigger( event, null, buttonDescendant );

--- a/test/test.js
+++ b/test/test.js
@@ -398,7 +398,7 @@ QUnit.test( "submitHandler keeps submitting button", function( assert ) {
 } );
 
 QUnit.test( "submitHandler keeps submitting button, even if descendants are clicked", function( assert ) {
-	var button, event, buttonDescendant;
+	var button;
 
 	$( "#testForm27" ).validate( {
 		debug: true,

--- a/test/test.js
+++ b/test/test.js
@@ -408,7 +408,7 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 			var hidden = $( form ).find( "input:hidden" )[ 0 ];
 			assert.deepEqual( hidden.value, button.value );
 			assert.deepEqual( hidden.name, button.name );
-			
+
 			return false;
 		}
 	} );

--- a/test/test.js
+++ b/test/test.js
@@ -417,6 +417,30 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 	$( button ).find( "span" ).click();
 } );
 
+QUnit.test( "submitHandler keeps submitting button", function( assert ) {
+	var button = $( "#testForm27 :submit" )[ 0 ];
+	var v = $( "#testForm27" ).validate( {
+		debug: true,
+		submitHandler: function( form ) {
+
+			// Compare the button with the `submitButton` property
+			assert.deepEqual(
+				v.submitButton, button, "The submitButton property should be the same as button"
+			);
+
+			var hidden = $( form ).find( "input:hidden" )[ 0 ];
+			assert.deepEqual( hidden.value, button.value );
+			assert.deepEqual( hidden.name, button.name );
+
+			return false;
+		}
+	} );
+
+	$( "#testForm27 [name=\"year\"]" ).val( "2016" );
+
+	$( button ).find( "span" ).click();
+} );
+
 QUnit.test( "validation triggered on radio/checkbox when using keyboard", function( assert ) {
     assert.expect( 1 );
 	var input, i, events, triggeredEvents = 0,

--- a/test/test.js
+++ b/test/test.js
@@ -408,14 +408,13 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 			var hidden = $( form ).find( "input:hidden" )[ 0 ];
 			assert.deepEqual( hidden.value, button.value );
 			assert.deepEqual( hidden.name, button.name );
+			
+			return false;
 		}
 	} );
 	$( "#testForm27 [name=\"year\"]" ).val( "2016" );
 	button = $( "#testForm27 :submit" )[ 0 ];
-	buttonDescendant = $( button ).find( "span" );
-	event = $.Event( "click" );
-	event.preventDefault();
-	$.event.trigger( event, null, buttonDescendant );
+	$( button ).find( "span" ).click();
 } );
 
 QUnit.test( "validation triggered on radio/checkbox when using keyboard", function( assert ) {

--- a/test/test.js
+++ b/test/test.js
@@ -416,7 +416,6 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 	event = $.Event( "click" );
 	event.preventDefault();
 	$.event.trigger( event, null, buttonDescendant );
-	$( "#testForm27" ).submit();
 } );
 
 QUnit.test( "validation triggered on radio/checkbox when using keyboard", function( assert ) {

--- a/test/test.js
+++ b/test/test.js
@@ -412,7 +412,7 @@ QUnit.test( "submitHandler keeps submitting button, even if descendants are clic
 	} );
 	$( "#testForm27 [name=\"year\"]" ).val( "2016" );
 	button = $( "#testForm27 :submit" )[ 0 ];
-	buttonDescendant = $(button).find("span");
+	buttonDescendant = $(button).find( "span" );
 	event = $.Event( "click" );
 	event.preventDefault();
 	$.event.trigger( event, null, buttonDescendant );


### PR DESCRIPTION
JSFiddle -
https://jsfiddle.net/0b3we0gm/9/ (with the fix)
https://jsfiddle.net/0c8nvnob/7/ (without the fix)

Non-Firefox browsers dispatch `click` on descendants of `<button>`, which breaks
the submitHandler logic that adds a hidden field with the name and value of the
submit button (since it is not included in the submission if it did not
initiate the submission, which might be the case when using `form.submit` in
`submitHandler` and returning `false`). `submitButton` is instead a descendant of
`<button>` and the hidden field does not compensate for the lack of an actual
submit button.

This would fix https://crbug.com/668524 and make `submitButton` an actual button.

The issue is reproducible in Chrome.
Firefox does not dispatch events to the descendants of `<button>` (but the specification requires that it will, see https://bugzilla.mozilla.org/show_bug.cgi?id=1089326 for details). The rest of the gang dispatch events to the descendants, so I imagine the problem exists in all of them and not just in Chrome.