### PR TITLE
Core: Add support for defining a global normalizer

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -717,21 +717,27 @@ $.extend( $.validator, {
 				} ).length,
 				dependencyMismatch = false,
 				val = this.elementValue( element ),
-				result, method, rule;
+				result, method, rule, normalizer;
 
-			// If a normalizer is defined for this element, then
-			// call it to retreive the changed value instead
+			// Prioritize the local normalizer defined for this element over the global one
+			// if the former exists, otherwise user the global one in case it exists.
+			if ( typeof rules.normalizer === "function" ) {
+				normalizer = rules.normalizer;
+			} else if (	typeof this.settings.normalizer === "function" ) {
+				normalizer = this.settings.normalizer;
+			}
+
+			// If normalizer is defined, then call it to retreive the changed value instead
 			// of using the real one.
 			// Note that `this` in the normalizer is `element`.
-			if ( typeof rules.normalizer === "function" ) {
-				val = rules.normalizer.call( element, val );
+			if ( normalizer ) {
+				val = normalizer.call( element, val );
 
 				if ( typeof val !== "string" ) {
 					throw new TypeError( "The normalizer should return a string value." );
 				}
 
-				// Delete the normalizer from rules to avoid treating
-				// it as a pre-defined method.
+				// Delete the normalizer from rules to avoid treating it as a pre-defined method.
 				delete rules.normalizer;
 			}
 

--- a/test/rules.js
+++ b/test/rules.js
@@ -308,7 +308,7 @@ QUnit.test( "rules(), rangelength attribute as array", function( assert ) {
 	} );
 } );
 
-QUnit.test( "rules(), normalizer", function( assert ) {
+QUnit.test( "rules(), global/local normalizer", function( assert ) {
 	var username = $( "#usernamec" ),
 		urlc = $( "#urlc" ),
 		lastname = $( "#lastnamec" ),
@@ -318,18 +318,21 @@ QUnit.test( "rules(), normalizer", function( assert ) {
 	urlc.val( "" );
 
 	v = $( "#testForm1clean" ).validate( {
+
+		// Using the normalizer to trim the value of all elements before validating them.
+		normalizer: function( value ) {
+
+			// This normalizer should only be called for the username element, and nothing else.
+			assert.notEqual( this, urlc[ 0 ], "This normalizer should not be called for urlc element." );
+			assert.equal( this, username[ 0 ], "`this` in this normalizer should be the username element." );
+
+			// Trim the value of the input
+			return $.trim( value );
+		},
+
 		rules: {
 			username: {
-				required: true,
-
-				// Using the normalizer to trim the value of the element
-				// before validating it.
-				normalizer: function( value ) {
-					assert.equal( this, username[ 0 ], "`this` in the normalizer should be the username element." );
-
-					// Trim the value of the input
-					return $.trim( value );
-				}
+				required: true
 			},
 			urlc: {
 				required: true,
@@ -357,13 +360,10 @@ QUnit.test( "rules(), normalizer", function( assert ) {
 			},
 			lastname: {
 				required: true,
-
-				// Using the normalizer to trim the value of the element
-				// before validating it.
 				normalizer: function( value ) {
 					assert.equal( this, lastname[ 0 ], "`this` in the normalizer should be the lastname element." );
 
-					// Return null in order to make sure a exception is thrown
+					// Return null in order to make sure an exception is thrown
 					// when normalizer returns a non string value.
 					value = null;
 


### PR DESCRIPTION
This PR added support for using a global normalizer for all elements of the form, which will run for all elements if it's present in the top level (the same level as `rules`) without affecting the current behaviour, that way you can transform the values of a set of elements without attaching the same normalizer to the aforementioned elements, and you can override it on element level by specifying a normalizer for the specific element that you want to transform differently.

In pseudo code, this will look like:

``` js
$("#myForm").validate({
  normalizer: function(value) {
    // Trim the value of every element
    return $.trim(value);
  },
  rules: {
    username: {
      required: true,
      // Here, we override the global normalizer
      normalizer: function(value) {
        value = value.replace("something", "new thing");
        return $.trim(value);
      }
    }
  }
});
```
