### PR TITLE
reset name property on elements, to support contenteditables

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -614,6 +614,9 @@ $.extend( $.validator, {
 					console.error( "%o has no name assigned", this );
 				}
 
+				// reset name property, because contenteditables do not per se have that named property
+				this.name = name;
+
 				// Set form expando on contenteditable
 				if ( this.hasAttribute( "contenteditable" ) ) {
 					this.form = $( this ).closest( "form" )[ 0 ];

--- a/src/core.js
+++ b/src/core.js
@@ -614,7 +614,7 @@ $.extend( $.validator, {
 					console.error( "%o has no name assigned", this );
 				}
 
-				// reset name property, because contenteditables do not per se have that named property
+				// Reset name property, because contenteditables do not per se have that named property
 				this.name = name;
 
 				// Set form expando on contenteditable


### PR DESCRIPTION
### Checklist for this pull request
Before submitting a pull request, please make sure to follow these rules:

* Your code should contain tests relevant for the problem you are solving.
* Your commits messages format should follow the jQuery git commit message format (http://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines).
* The pull request should reference existing issues or link to a reproducible demo.
* Please review the guidelines for contributing (CONTRIBUTING.md) to this repository for more information.

#### Description
contenteditables do not have the name property per se. Using that elements name property, e.g. to reference any respective error message, fails. Hence, I reset the element's name property, after reading it out or using its name-attribute. This should fix it. 

Thank you!
