### PR TITLE
Additional: Fixed validation for specific case for Spanish NIFs.

### DIFF
--- a/src/additional/nifES.js
+++ b/src/additional/nifES.js
@@ -18,7 +18,7 @@ $.validator.addMethod( "nifES", function( value ) {
 
 	// Test specials NIF (starts with K, L or M)
 	if ( /^[KLM]{1}/.test( value ) ) {
-		return ( value[ 8 ] === String.fromCharCode( 64 ) );
+		return ( value[ 8 ] === "TRWAGMYFPDXBNJZSQVHLCKE".charAt( value.substring( 8, 1 ) % 23 ) );
 	}
 
 	return false;

--- a/test/methods.js
+++ b/test/methods.js
@@ -1316,6 +1316,7 @@ QUnit.test( "nifES", function( assert ) {
 	assert.ok( method( "15762034L" ), "NIF valid" );
 	assert.ok( method( "05122654W" ), "NIF valid" );
 	assert.ok( method( "05122654w" ), "NIF valid: lower case" );
+	assert.ok( method( "M1503708Z" ), "NIF valid. Temporary foreign nif" );
 	assert.ok( !method( "1144105R" ), "NIF invalid: less than 8 digits without zero" );
 	assert.ok( !method( "11441059 R" ), "NIF invalid: white space" );
 	assert.ok( !method( "11441059" ), "NIF invalid: no letter" );


### PR DESCRIPTION
Fixed bug in validation of Spanish nif for specific case of temporary foreign NIFs.
Added test for specific case.

Closes #1913

Thank you!
